### PR TITLE
Polymarket

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ all: deploy
 
 deploy: questions workflows metadata curate-questions resolve
 
-questions: manifold metaculus acled infer yfinance
+questions: manifold metaculus acled infer yfinance polymarket
 
 workflows: main-workflow
 
@@ -106,6 +106,14 @@ yfinance-fetch:
 
 yfinance-update-questions:
 	make -C src/questions/yfinance/update_questions
+
+polymarket: polymarket-fetch polymarket-update-questions
+
+polymarket-fetch:
+	make -C src/questions/polymarket/fetch
+
+polymarket-update-questions:
+	make -C src/questions/polymarket/update_questions
 
 tag-questions:
 	make -C src/metadata/tag_questions

--- a/src/questions/polymarket/.gcloudignore.add
+++ b/src/questions/polymarket/.gcloudignore.add
@@ -1,0 +1,2 @@
+# .gcloudignore.add
+helpers/llm_prompts.py

--- a/src/questions/polymarket/fetch/Makefile
+++ b/src/questions/polymarket/fetch/Makefile
@@ -1,0 +1,40 @@
+all :
+	$(MAKE) clean
+	$(MAKE) deploy
+
+.PHONY : all clean deploy
+
+UPLOAD_DIR = upload
+
+# additional .gcloudignore for polymayket to ignore llm_prompts.py, which does not work with
+# python 3.9
+GCLOUDIGNORE_ADDITIONAL = $(ROOT_DIR)src/questions/polymarket/.gcloudignore.add
+
+.gcloudignore: $(GCLOUDIGNORE_ADDITIONAL)
+	cp -r $(ROOT_DIR)src/helpers/.gcloudignore .
+	cat $^ >> .gcloudignore
+
+# Python 3.9 runtime required for `py_clob_client` library
+deploy : main.py .gcloudignore requirements.txt
+	mkdir -p $(UPLOAD_DIR)
+	cp -r $(ROOT_DIR)utils $(UPLOAD_DIR)/
+	cp -r $(ROOT_DIR)src/helpers $(UPLOAD_DIR)/
+	cp $^ $(UPLOAD_DIR)/
+	gcloud functions deploy \
+		polymarket_fetch \
+		--project $(CLOUD_PROJECT) \
+		--region $(CLOUD_DEPLOY_REGION) \
+		--entry-point driver \
+		--runtime python39 \
+		--memory 2GiB \
+		--max-instances 1 \
+		--timeout 3000s \
+		--service-account $(CLOUD_STORAGE_BUCKET_QUESTION_BANK_SERVICE_ACCOUNT) \
+		--trigger-http \
+		--no-allow-unauthenticated \
+		--gen2 \
+		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS) \
+		--source $(UPLOAD_DIR)
+
+clean :
+	rm -rf $(UPLOAD_DIR) .gcloudignore

--- a/src/questions/polymarket/fetch/main.py
+++ b/src/questions/polymarket/fetch/main.py
@@ -1,0 +1,278 @@
+"""POLYMARKET fetch new questions script."""
+
+import json
+import logging
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pandas as pd
+import requests
+from py_clob_client.client import ClobClient
+from py_clob_client.constants import POLYGON
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
+from helpers import constants, data_utils, dates, decorator, keys  # noqa: E402
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
+from utils import gcp  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+API_KEY_POLYMARKET = keys.get_secret("API_KEY_POLYMARKET")
+SOURCE = "polymarket"
+client = ClobClient("https://clob.polymarket.com", key=API_KEY_POLYMARKET, chain_id=POLYGON)
+
+
+def fetch_price_history(market_id):
+    """
+    Retrieve the price history of a market from the Polymarket API.
+
+    Note: polymarket API seem to only provide the history up to the last 6 month.
+
+    Args:
+    market_id (str): The unique identifier of the market.
+
+    Returns:
+    list: A list of dictionaries containing the price history data, or an empty list
+          if the data retrieval fails.
+    """
+    url = (
+        f"https://clob.polymarket.com/prices-history?interval=all&market="
+        f"{market_id}&fidelity=60"
+    )
+
+    response = requests.get(url)
+
+    if response.status_code == 200:
+        data = response.json()
+        history_data = data.get("history", [])
+        return history_data
+
+
+def fetch_all_questions(dfq):
+    """
+    Fetch all questions.
+
+    Combine new questions from the API with unresolved questions
+    from existing data. It filters out questions that have less than 10 price history points, and
+    formats the data for further processing. It ensures no duplicate questions are fetched if they
+    are already marked as unresolved in the current dataset.
+
+    Parameters:
+    - dfq (DataFrame): A pandas DataFrame containing the current unresolved questions with
+    columns "id" and "resolved".
+
+    Returns:
+    - List[Dict]: A list of dictionaries with details of all unresolved questions, including
+    their resolutions.
+    """
+    all_new_questions = []
+    current_time = dates.get_date_today()
+    yesterday = current_time - timedelta(days=1)
+    next_cursor = None
+    page_cnt = 1
+    drop_cnt = 0
+    bet_cnt = 1000
+
+    while True:
+        resp = client.get_markets(next_cursor=next_cursor) if next_cursor else client.get_markets()
+
+        new_questions = []
+
+        for q in resp["data"]:
+            if not q["closed"] and not q["archived"]:
+                token_index = 0
+                if q["tokens"][0]["outcome"] != "Yes":
+                    token_index = 1
+
+                price_history = []
+                # If there are no bets,fetch_price_history will get 400 status error
+                if q["tokens"][token_index]["token_id"]:
+                    price_history = fetch_price_history(q["tokens"][token_index]["token_id"])
+                else:
+                    drop_cnt += 1
+
+                if len(price_history) >= bet_cnt:
+                    # only save questions with at least 10 predictions
+                    q["price_history"] = price_history
+                    new_questions.append(q)
+                else:
+                    drop_cnt += 1
+
+        all_new_questions.extend(new_questions)
+        next_cursor = resp.get("next_cursor", None)
+
+        # Check if there are no more pages of data
+        if next_cursor is None or next_cursor == "LTE=":
+            logger.info("No more pages to fetch.")
+            break
+
+        logger.info(
+            f"Current page is {page_cnt}."
+            + f" Current question count is {len(all_new_questions)}."
+            + f" Current drop count is {drop_cnt}."
+        )
+
+        page_cnt += 1
+
+    # Fetch unresolved question IDs from current_data if it's not empty
+    if not dfq.empty:
+        unresolved_ids = set(dfq.loc[~dfq["resolved"], "id"])
+    else:
+        unresolved_ids = set()
+
+    all_newly_fetched_ids = {q["condition_id"] for q in all_new_questions}
+    unresolved_ids.difference_update(all_newly_fetched_ids)
+
+    # Convert back to list if necessary
+    unresolved_ids = list(unresolved_ids)
+
+    all_existing_unresolved_questions = []
+
+    for id_ in unresolved_ids:
+        current_existing_market = client.get_market(condition_id=id_)
+        if current_existing_market["tokens"][0]["outcome"] != "Yes":
+            price_history = fetch_price_history(q["tokens"][1]["token_id"])
+        else:
+            price_history = fetch_price_history(q["tokens"][0]["token_id"])
+        current_existing_market["price_history"] = price_history
+        all_existing_unresolved_questions.append(current_existing_market)
+
+    logger.info("Finished fetching unresolved questions!")
+
+    all_questions_to_add = all_new_questions + all_existing_unresolved_questions
+    all_questions_to_add = [q for q in all_questions_to_add if q["price_history"]]
+
+    logger.info("move on to processing")
+
+    all_complete_questions = []
+
+    for q in all_questions_to_add:
+        price_history = q["price_history"]
+
+        if len(price_history) > 0:
+
+            converted_price_history = [
+                {"date": dates.convert_epoch_time_in_sec_to_iso(r["t"]), "value": r["p"]}
+                for r in price_history
+            ]
+
+            final_resolutions_df = pd.DataFrame(converted_price_history)
+            final_resolutions_df["date"] = pd.to_datetime(final_resolutions_df["date"].str[:10])
+
+            # Sort and remove duplicates to keep the latest entry per date
+            final_resolutions_df.drop_duplicates(subset=["date"], keep="last", inplace=True)
+
+            # Reindex to fill in missing dates including weekends
+            all_dates = pd.date_range(
+                start=final_resolutions_df["date"].min(), end=yesterday, freq="D"
+            )
+            final_resolutions_df = (
+                final_resolutions_df.set_index("date")
+                .reindex(all_dates, method="ffill")
+                .reset_index()
+            )
+
+            final_resolutions_df["id"] = q["condition_id"]
+            final_resolutions_df.rename(columns={"index": "date"}, inplace=True)
+
+            final_resolutions_df = final_resolutions_df[["id", "date", "value"]]
+
+        else:
+            final_resolutions_df = pd.DataFrame([], columns=["id", "date", "value"])
+
+        current_prob = price_history[-1]["p"] if len(price_history) > 1 else 0
+        resolved_date = dates.convert_zulu_to_iso(q["end_date_iso"]) if q["end_date_iso"] else "N/A"
+
+        # get horizons
+        forecast_horizons = constants.FORECAST_HORIZONS_IN_DAYS
+        if q["closed"]:
+            forecast_horizons = []
+        elif resolved_date != "N/A":
+            forecast_horizons = data_utils.get_horizons(datetime.fromisoformat(resolved_date))
+
+        # Get the resolution if the question is closed
+        if q["closed"]:
+            current_prob = 1
+            if (q["tokens"][0]["outcome"] == "No" and q["tokens"][0]["winner"]) or (
+                q["tokens"][1]["outcome"] == "No" and q["tokens"][1]["winner"]
+            ):
+                current_prob = 0
+            # add the resolution to the last row of the resolution df if it's resolved
+            final_resolutions_df["date"] = pd.to_datetime(final_resolutions_df["date"])
+            if final_resolutions_df.empty:
+                next_day = resolved_date
+            else:
+                next_day = final_resolutions_df["date"].iloc[-1] + pd.Timedelta(days=1)
+            # create the last row
+            new_row = pd.DataFrame(
+                {"id": [q["condition_id"]], "date": [next_day], "value": [current_prob]}
+            )
+            if final_resolutions_df.empty:
+                new_row["date"] = datetime.fromisoformat(next_day).strftime("%Y-%m-%d")
+                final_resolutions_df = new_row
+            else:
+                final_resolutions_df = pd.concat([final_resolutions_df, new_row], ignore_index=True)
+                final_resolutions_df["date"] = final_resolutions_df["date"].dt.strftime("%Y-%m-%d")
+
+        final_resolutions_df["date"] = final_resolutions_df["date"].astype(str)
+
+        all_complete_questions.append(
+            {
+                "id": q["condition_id"],
+                "question": q["question"],
+                "background": q["description"],
+                "source_resolution_criteria": "N/A",
+                "source_begin_datetime": "N/A",
+                "source_close_datetime": resolved_date,
+                "url": "https://polymarket.com/event/" + q["market_slug"],
+                # this url won't work if this question is a sub-question
+                "resolved": q["closed"],
+                "source_resolution_datetime": resolved_date,
+                "fetch_datetime": dates.get_datetime_now(),
+                "probability": current_prob,
+                "continual_resolution": False,
+                "forecast_horizons": forecast_horizons,
+                "value_at_freeze_datetime": current_prob,
+                "value_at_freeze_datetime_explanation": "The market price.",
+                "historical_prices": final_resolutions_df.to_dict(orient="records"),
+            }
+        )
+
+    logger.info(f"Fetched {len(all_complete_questions)} questions.")
+
+    return pd.DataFrame(all_complete_questions)
+
+
+@decorator.log_runtime
+def driver(_):
+    """Execute the main workflow of fetching, processing, and uploading questions."""
+    # Download existing questions from cloud storage
+    dfq = data_utils.get_data_from_cloud_storage(SOURCE, return_question_data=True)
+
+    filenames = data_utils.generate_filenames(SOURCE)
+
+    # Get the latest data
+    all_questions_to_add = fetch_all_questions(dfq)
+
+    # Save and upload
+    with open(filenames["local_fetch"], "w", encoding="utf-8") as f:
+        for record in all_questions_to_add.to_dict(orient="records"):
+            json_str = json.dumps(record, ensure_ascii=False)
+            f.write(json_str + "\n")
+
+    # Upload
+    logger.info("Uploading to GCP...")
+    gcp.storage.upload(
+        bucket_name=constants.BUCKET_NAME,
+        local_filename=filenames["local_fetch"],
+    )
+
+    logger.info("Done.")
+    return "OK", 200
+
+
+if __name__ == "__main__":
+    driver(None)

--- a/src/questions/polymarket/fetch/requirements.txt
+++ b/src/questions/polymarket/fetch/requirements.txt
@@ -1,0 +1,7 @@
+google-cloud-storage
+requests
+certifi
+google-cloud-secret-manager
+pandas
+py_clob_client
+backoff

--- a/src/questions/polymarket/update_questions/Makefile
+++ b/src/questions/polymarket/update_questions/Makefile
@@ -1,0 +1,35 @@
+all :
+	$(MAKE) clean
+	$(MAKE) deploy
+
+.PHONY : all clean deploy
+
+UPLOAD_DIR = upload
+
+.gcloudignore:
+	cp -r $(ROOT_DIR)src/helpers/.gcloudignore .
+
+deploy : main.py .gcloudignore requirements.txt
+	$(eval LATEST_PYTHON_RUNTIME := $(shell gcloud functions runtimes list --format="value(name)" --filter="python" --region $(CLOUD_DEPLOY_REGION) | tail -n 1))
+	mkdir -p $(UPLOAD_DIR)
+	cp -r $(ROOT_DIR)utils $(UPLOAD_DIR)/
+	cp -r $(ROOT_DIR)src/helpers $(UPLOAD_DIR)/
+	cp $^ $(UPLOAD_DIR)/
+	gcloud functions deploy \
+		polymarket_update_questions \
+		--project $(CLOUD_PROJECT) \
+		--region $(CLOUD_DEPLOY_REGION) \
+		--entry-point driver \
+		--runtime $(LATEST_PYTHON_RUNTIME) \
+		--memory 512MB \
+		--max-instances 1 \
+		--timeout 540s \
+		--service-account $(CLOUD_STORAGE_BUCKET_QUESTION_BANK_SERVICE_ACCOUNT) \
+		--trigger-http \
+		--no-allow-unauthenticated \
+		--no-gen2 \
+		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS) \
+		--source $(UPLOAD_DIR)
+
+clean :
+	rm -rf $(UPLOAD_DIR) .gcloudignore

--- a/src/questions/polymarket/update_questions/main.py
+++ b/src/questions/polymarket/update_questions/main.py
@@ -1,0 +1,143 @@
+"""Polymarket update question script."""
+
+import logging
+import os
+import sys
+from datetime import timedelta
+
+import pandas as pd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))  # noqa: E402
+from helpers import constants, data_utils, dates, decorator  # noqa: E402
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
+from utils import gcp  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+SOURCE = "polymarket"
+
+
+def create_resolution_file(question, source=SOURCE):
+    """
+    Create or update a resolution file based on the question ID provided. Download the existing file, if any.
+
+    Check the last entry date, and update with new data if there's no entry for today. Upload the updated file
+    back to the specified Google Cloud Platform bucket.
+
+    Args:
+    - question (dict): A dictionary containing at least the 'id' of the question.
+    - source (str): The source directory path within the bucket where files are stored.
+
+    Returns:
+    - DataFrame: Return the current state of the resolution file as a DataFrame if no update is needed.
+      If an update occurs, the function returns None after uploading the updated file.
+    """
+    basename = f"{question['id']}.jsonl"
+    remote_filename = f"{source}/{basename}"
+    local_filename = "/tmp/tmp.jsonl"
+
+    gcp.storage.download_no_error_message_on_404(
+        bucket_name=constants.BUCKET_NAME,
+        filename=remote_filename,
+        local_filename=local_filename,
+    )
+    current_df = pd.read_json(
+        local_filename,
+        lines=True,
+        dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE,
+        convert_dates=False,
+    )
+
+    yesterday = dates.get_date_today() - timedelta(days=1)
+
+    if not current_df.empty and pd.to_datetime(current_df["date"].iloc[-1]).date() >= yesterday:
+        logger.info(f"{question['id']} is skipped because it's already up-to-date!")
+        # Check last date to see if we've already gotten the resolution value for today
+        # If we have it alreeady, return to avoid unnecessary API calls
+        return False
+
+    fetch_df = pd.DataFrame(question["historical_prices"])
+
+    if not current_df.empty:
+        # combine the newly fetched prices with the previously fetched prices.
+        final_df = pd.concat([current_df, fetch_df]).drop_duplicates().reset_index(drop=True)
+    else:
+        final_df = fetch_df.copy()
+
+    final_df = final_df[["id", "date", "value"]].astype(
+        dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE
+    )
+    final_df.to_json(local_filename, orient="records", lines=True, date_format="iso")
+    gcp.storage.upload(
+        bucket_name=constants.BUCKET_NAME,
+        local_filename=local_filename,
+        filename=remote_filename,
+    )
+
+    return True
+
+
+def update_questions(dfq, dff):
+    """
+    Update the dataframes with new or modified question data and new community predictions.
+
+    Parameters:
+    - dfq (pd.DataFrame): DataFrame containing all existing questions.
+    - dff  (pd.DataFrame): DataFrame containing all newly fetched questions.
+
+    The function updates dfq by either replacing existing questions with new data or adding new questions.
+    It also appends new community predictions to dfr for each question in all_questions_to_add.
+    """
+    dff_list = dff.to_dict("records")
+    for question in dff_list:
+
+        result_TF = create_resolution_file(question)
+
+        # only update the question info if we modify(update/create) the resolution file
+        # If the resolution come out today, the resolution file won't be updated
+        # and we should not change the question status to resolved, otherwise once we
+        # change its status to resolved, it won't append the actual resolution to the resolution file
+        if result_TF:
+
+            del question["fetch_datetime"]
+            del question["probability"]
+            del question["historical_prices"]
+
+            # Check if the question exists in dfq
+            if question["id"] in dfq["id"].values:
+                # Case 1: Update existing question
+                dfq_index = dfq.index[dfq["id"] == question["id"]].tolist()[0]
+                for key, value in question.items():
+                    dfq.at[dfq_index, key] = value
+            else:
+                # Case 2: Append new question
+                new_q_row = pd.DataFrame([question])
+                new_q_row = new_q_row.astype(constants.QUESTION_FILE_COLUMN_DTYPE)
+                dfq = pd.concat([dfq, new_q_row], ignore_index=True)
+
+    return dfq
+
+
+@decorator.log_runtime
+def driver(_):
+    """Execute the main workflow of fetching, processing, and uploading questions."""
+    # Download existing questions from cloud storage
+    dfq, dff = data_utils.get_data_from_cloud_storage(
+        SOURCE, return_question_data=True, return_fetch_data=True
+    )
+
+    # Update the existing questions
+    dfq = update_questions(dfq, dff)
+
+    logger.info("Uploading to GCP...")
+    # Save and upload
+    data_utils.upload_questions(dfq, SOURCE)
+    logger.info("Done.")
+
+    return "OK", 200
+
+
+if __name__ == "__main__":
+    driver(None)

--- a/src/questions/polymarket/update_questions/requirements.txt
+++ b/src/questions/polymarket/update_questions/requirements.txt
@@ -1,0 +1,3 @@
+google-cloud-storage
+google-cloud-secret-manager
+pandas

--- a/src/workflow/step1.yaml
+++ b/src/workflow/step1.yaml
@@ -17,6 +17,7 @@ main:
               - metaculus
               - infer
               - yfinance
+              - polymarket
             steps:
               - run:
                   try:


### PR DESCRIPTION
#11 

Polymarket API can only allow users to fetch all historical prices all at once instead of the latest price, so I added a field in the fetch.jsonl, called historical_prices, which has all the resolutions up till fetch_datetime. Then, in update_questions, it uploads each resolution file and then deletes that field before saving each question into question.jsonl.