### PR TITLE
Metaculus: make idempotent

### DIFF
--- a/src/helpers/constants.py
+++ b/src/helpers/constants.py
@@ -1,0 +1,37 @@
+"""Constants."""
+
+import os
+
+BUCKET_NAME = os.environ.get("CLOUD_STORAGE_BUCKET")
+
+QUESTION_FILE_COLUMN_DTYPE = {
+    "id": str,
+    "question": str,
+    "background": str,
+    "source_resolution_criteria": str,
+    "begin_datetime": str,
+    "close_datetime": str,
+    "url": str,
+    "resolution_datetime": str,
+    "resolved": bool,
+}
+QUESTION_FILE_COLUMNS = list(QUESTION_FILE_COLUMN_DTYPE.keys())
+
+RESOLUTION_FILE_COLUMN_DTYPE = {
+    "id": str,
+    "datetime": str,
+}
+
+# value is not included in dytpe because it's of type ANY
+RESOLUTION_FILE_COLUMNS = list(RESOLUTION_FILE_COLUMN_DTYPE.keys()) + ["value"]
+
+MANIFOLD_TOPIC_SLUGS = ["entertainment", "sports-default", "technology-default"]
+
+METACULUS_CATEGORIES = [
+    "geopolitics",
+    "natural-sciences",
+    "sports-entertainment",
+    "health-pandemics",
+    "law",
+    "computing-and-math",
+]

--- a/src/questions/manifold/fetch/main.py
+++ b/src/questions/manifold/fetch/main.py
@@ -10,7 +10,7 @@ import certifi
 import requests
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
-from helpers import data_utils  # noqa: E402
+from helpers import constants, data_utils  # noqa: E402
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from utils import gcp  # noqa: E402
@@ -19,8 +19,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 filenames = data_utils.generate_filenames(source="manifold")
-bucket_name = os.environ.get("CLOUD_STORAGE_BUCKET")
-manifold_topic_slugs = ["entertainment", "sports-default", "technology-default"]
 
 
 @backoff.on_exception(
@@ -66,7 +64,7 @@ def _get_data(topics):
 def driver(_):
     """Fetch Manifold data and update question file in GCP Cloud Storage."""
     # Get the latest Manifold data
-    ids = _get_data(manifold_topic_slugs)
+    ids = _get_data(constants.MANIFOLD_TOPIC_SLUGS)
 
     # Save
     with open(filenames["local_fetch"], "w") as f:
@@ -75,7 +73,7 @@ def driver(_):
 
     # Upload
     gcp.storage.upload(
-        bucket_name=bucket_name,
+        bucket_name=constants.BUCKET_NAME,
         local_filename=filenames["local_fetch"],
     )
 

--- a/src/questions/metaculus/fetch/main.py
+++ b/src/questions/metaculus/fetch/main.py
@@ -7,12 +7,10 @@ import sys
 
 import backoff
 import certifi
-import numpy as np
-import pandas as pd
 import requests
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
-from helpers import data_utils, dates  # noqa: E402
+from helpers import constants, data_utils  # noqa: E402
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from utils import gcp  # noqa: E402
@@ -20,17 +18,7 @@ from utils import gcp  # noqa: E402
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-source = "metaculus"
-local_filename = f"/tmp/{source}_fetch.jsonl"
-bucket_name = os.environ.get("CLOUD_STORAGE_BUCKET")
-metaculus_categories = [
-    "geopolitics",
-    "natural-sciences",
-    "sports-entertainment",
-    "health-pandemics",
-    "law",
-    "computing-and-math",
-]
+filenames = data_utils.generate_filenames(source="metaculus")
 API_KEY = os.environ.get("API_KEY_METACULUS")
 
 
@@ -40,7 +28,7 @@ API_KEY = os.environ.get("API_KEY_METACULUS")
     max_time=300,
     on_backoff=data_utils.print_error_info_handler,
 )
-def _call_endpoint(df, additional_params=None):
+def _call_endpoint(ids, additional_params=None):
     """Get the top 100 markets from Metaculus."""
     endpoint = "https://www.metaculus.com/api2/questions/"
     params = {
@@ -54,82 +42,40 @@ def _call_endpoint(df, additional_params=None):
     if additional_params:
         params.update(additional_params)
     logger.info(f"Calling {endpoint} with additional params {additional_params}")
+
     headers = {"Authorization": f"Token {API_KEY}"}
     response = requests.get(endpoint, params=params, headers=headers, verify=certifi.where())
-    utc_datetime_str = dates.get_datetime_now()
     if not response.ok:
         logger.error("Request to Metaculus API endpoint failed.")
         response.raise_for_status()
-    df_tmp = pd.DataFrame(response.json()["results"])
 
-    if df.empty and df_tmp.empty:
-        return df
-
-    if not df_tmp.empty:
-        # removing potentially null columns to avoid `pd.concat` FutureWarning
-        df_tmp = df_tmp[
-            ["id", "title", "publish_time", "close_time", "page_url", "community_prediction"]
-        ]
-        df_tmp["fetch_datetime"] = utc_datetime_str
-        df = df_tmp if df.empty else pd.concat([df, df_tmp], ignore_index=True)
-
-    return df
+    ids.update(str(market["id"]) for market in response.json()["results"])
+    return ids
 
 
 def _get_data(topics):
     """Get pertinent Metaculus questions and data."""
     logger.info("Calling Metaculus search-markets endpoint")
-    df = _call_endpoint(pd.DataFrame())
+    ids = _call_endpoint(set())
     for topic in topics:
-        df = _call_endpoint(df, {"search": f"include:{topic}"})
-
-    def _extract_probability(market):
-        """Parse the forecasts for the community prediction presented on Metaculus.
-
-        Modifying the API data here because it's too much to keep in git and we can always backout
-        the Metaculus forecasts using the API if there's an error here.
-        """
-        market_value = market["full"]
-        return market_value.get("q2") if isinstance(market_value, dict) else np.nan
-
-    df = df.drop_duplicates(subset="id", keep="first", ignore_index=True)
-    df["fetch_datetime"] = df["fetch_datetime"]
-    df["question"] = df["title"]
-    df["background"] = "N/A"
-    df["source_resolution_criteria"] = "N/A"
-    df["begin_datetime"] = df["publish_time"].apply(dates.convert_zulu_to_iso)
-    df["close_datetime"] = df["close_time"].apply(dates.convert_zulu_to_iso)
-    df["url"] = "https://www.metaculus.com" + df["page_url"]
-    df["resolved"] = False
-    df["resolution_datetime"] = "N/A"
-    df["probability"] = df["community_prediction"].apply(_extract_probability)
-    df = df.dropna(subset=["probability"])
-    df = df.astype(data_utils.QUESTION_FILE_COLUMN_DTYPE)
-    return df[
-        data_utils.QUESTION_FILE_COLUMNS
-        + [
-            "fetch_datetime",
-            "probability",
-        ]
-    ].sort_values(by="id")
+        ids = _call_endpoint(ids, {"search": f"include:{topic}"})
+    return sorted(ids)
 
 
 def driver(_):
     """Fetch Metaculus data and update fetch file in GCP Cloud Storage."""
     # Get the latest Manifold data
-    df = _get_data(metaculus_categories)
+    ids = _get_data(constants.METACULUS_CATEGORIES)
 
     # Save
-    with open(local_filename, "w", encoding="utf-8") as f:
-        # can't use `df.to_json` because we don't want escape chars
-        for record in df.to_dict(orient="records"):
-            json_str = json.dumps(record, ensure_ascii=False)
-            f.write(json_str + "\n")
+    with open(filenames["local_fetch"], "w") as f:
+        for id_str in ids:
+            f.write(json.dumps({"id": id_str}) + "\n")
 
     # Upload
     gcp.storage.upload(
-        bucket_name=bucket_name,
-        local_filename=local_filename,
+        bucket_name=constants.BUCKET_NAME,
+        local_filename=filenames["local_fetch"],
     )
     logger.info("Done.")
 


### PR DESCRIPTION
Making the function idempotent makes it resilient to request errors and the Metaculus server being
down.

* save resolutions by market id in the `metaculus/` directory
