### PR TITLE
use gpt-3.5-turbo-0125 to validate questions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ questions: manifold metaculus acled infer yfinance
 
 workflows: main-workflow
 
-metadata: tag-questions
+metadata: tag-questions validate-questions
 
 curate-questions:
 	make -C src/curate_questions
@@ -107,6 +107,9 @@ yfinance-update-questions:
 
 tag-questions:
 	make -C src/metadata/tag_questions
+
+validate-questions:
+	make -C src/metadata/validate_questions
 
 leaderboard:
 	make -C src/leaderboard

--- a/src/helpers/constants.py
+++ b/src/helpers/constants.py
@@ -50,6 +50,10 @@ FREEZE_QUESTION_SOURCES = {
     },
 }
 
+DATA_SOURCES = [
+    "acled",
+]
+
 FREEZE_WINDOW_IN_DAYS = 7
 
 FREEZE_DATETIME = os.environ.get("FREEZE_DATETIME", dates.get_datetime_today()).replace(
@@ -134,6 +138,7 @@ META_DATA_FILE_COLUMN_DTYPE = {
     "source": str,
     "id": str,
     "category": str,
+    "valid_question": bool,
 }
 META_DATA_FILE_COLUMNS = list(META_DATA_FILE_COLUMN_DTYPE.keys())
 META_DATA_FILENAME = "question_metadata.jsonl"

--- a/src/helpers/data_utils.py
+++ b/src/helpers/data_utils.py
@@ -57,7 +57,11 @@ def download_and_read(filename, local_filename, df_tmp, dtype):
         local_filename=local_filename,
     )
     df = pd.read_json(local_filename, lines=True, dtype=dtype, convert_dates=False)
-    return df.astype(dtype=dtype) if not df.empty else df_tmp
+    if df.empty:
+        return df_tmp
+    # Allows us to pass a dtype that may contain column names that are not in the df
+    dtype_modified = {k: v for k, v in dtype.items() if k in df.columns}
+    return df.astype(dtype=dtype_modified) if dtype_modified else df
 
 
 def get_data_from_cloud_storage(

--- a/src/helpers/llm_prompts.py
+++ b/src/helpers/llm_prompts.py
@@ -278,3 +278,50 @@ Rules:
 
 Answer:"""
 )
+
+
+VALIDATE_QUESTION_PROMPT = """I want to assess the quality of a forecast question.
+
+Here is the forecast question: {question}.
+
+Please flag questions that don't seem appropriate by outputting "flag". Otherwise, if it seems like a reasonable question or if you're unsure, output "ok."
+
+In general, poorly-defined questions, questions that are sexual in nature, questions that are too personal, questions about the death/life expectancy of an individual should be flagged or, more generally, questions that are not in the public interest should be flagged. Geopolitical questions, questions about court cases, the entertainment industry, wars, public figures, and, more generally, questions in the public interest should be marked as "ok."
+
+Examples of questions that should be flagged:
+* "Will I finish my homework tonight?"
+* "Metaculus party 2023"
+* "Will Hell freeze over?"
+* "Heads or tails?"
+* "Will I get into MIT?"
+* "Will this video reach 100k views by the EOD?"
+* "If @Aella goes on the Whatever podcast, will she regret it?"
+* "Daily coinflip"
+* "Musk vs Zuckerberg: Will either of them shit their pants on the mat?"
+
+Examples of questions that should NOT be flagged:
+* "Will Megan Markle and Prince Harry have a baby by the end of the year?"
+* "Will the Brain Preservation Foundation's Large Mammal preservation prize be won by Feb 9th, 2017?"
+* "Will there be more novel new drugs approved by the FDA in 2016 than in 2015?"
+* "Will Israel invade Rafah in May 2024?"
+* "Will Iraq return its ambassador to Iran in the next month?"
+* "Tiger Woods Will Win Another PGA Tournament"
+* "Will Dwayne Johnson win the 2024 US Presidential Election?"
+* "Will Oppenheimer win best picture AND Bitcoin reach $70K AND Nintendo announce a new console by EOY 2024?"
+* "Will anybody born before 2000 live to be 150?"
+* "Will Taylor Swift get married before Bitcoin reaches $100K USD?"
+* "Will Russia's total territory decrease by at least 20% before 2028?"
+* "Will Donald Trump be jailed or incarcerated before 2030?"
+* "If China invades Taiwan before 2035, will the US respond with military force?"
+* "Will there be a tsunami that kills at least 50,000 people before 2030?"
+* "Will there be a military conflict resulting in at least 50 deaths between the United States and China in 2024?"
+* "Will an AI system be reported to have successfully blackmailed someone for >$1000 by EOY 2028?"
+* "Will Vladimir Putin declare Martial Law in at least 3/4 of Russia before 2025?"
+
+Again, when in doubt, do NOT flag the question; mark it as "ok".
+
+Your response should take the following structure:
+Insert thinking:
+{{ insert your concise thoughts here }}
+Classification:
+{{ insert "flag" or "ok"}}"""  # noqa: B950

--- a/src/metadata/tag_questions/main.py
+++ b/src/metadata/tag_questions/main.py
@@ -54,6 +54,9 @@ def driver(_):
         ),
         dtype=constants.META_DATA_FILE_COLUMN_DTYPE,
     )
+    if "category" not in dfmeta.columns:
+        dfmeta["category"] = ""
+
     for source, _ in constants.FREEZE_QUESTION_SOURCES.items():
         logger.info(f"Getting categories for {source} questions.")
         dfq = data_utils.get_data_from_cloud_storage(

--- a/src/metadata/validate_questions/Makefile
+++ b/src/metadata/validate_questions/Makefile
@@ -1,0 +1,35 @@
+all :
+	$(MAKE) clean
+	$(MAKE) deploy
+
+.PHONY : all clean deploy
+
+UPLOAD_DIR = upload
+
+.gcloudignore:
+	cp -r $(ROOT_DIR)src/helpers/.gcloudignore .
+
+deploy : main.py .gcloudignore requirements.txt
+	$(eval LATEST_PYTHON_RUNTIME := $(shell gcloud functions runtimes list --format="value(name)" --filter="python" --region $(CLOUD_DEPLOY_REGION) | tail -n 1))
+	mkdir -p $(UPLOAD_DIR)
+	cp -r $(ROOT_DIR)utils $(UPLOAD_DIR)/
+	cp -r $(ROOT_DIR)src/helpers $(UPLOAD_DIR)/
+	cp $^ $(UPLOAD_DIR)/
+	gcloud functions deploy \
+		metadata_validate_questions \
+		--project $(CLOUD_PROJECT) \
+		--region $(CLOUD_DEPLOY_REGION) \
+		--entry-point driver \
+		--runtime $(LATEST_PYTHON_RUNTIME) \
+		--memory 2GiB \
+		--max-instances 1 \
+		--timeout 1800s \
+		--service-account $(CLOUD_STORAGE_BUCKET_QUESTION_BANK_SERVICE_ACCOUNT) \
+		--trigger-http \
+		--no-allow-unauthenticated \
+		--gen2 \
+		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS) \
+		--source $(UPLOAD_DIR)
+
+clean :
+	rm -rf $(UPLOAD_DIR) .gcloudignore

--- a/src/metadata/validate_questions/main.py
+++ b/src/metadata/validate_questions/main.py
@@ -1,0 +1,122 @@
+"""Generate meta data for questions to filter."""
+
+import logging
+import os
+import sys
+
+import pandas as pd
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../.."))
+from helpers import (  # noqa: E402
+    constants,
+    data_utils,
+    decorator,
+    llm_prompts,
+    model_eval,
+)
+
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))  # noqa: E402
+from utils import gcp  # noqa: E402
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def validate_questions(dfq):
+    """Validate question with gpt 3.5-turbo."""
+    invalid_questions = []
+    for index, row in dfq[dfq["valid_question"] == ""].iterrows():
+        question = row["question"]
+        prompt = llm_prompts.VALIDATE_QUESTION_PROMPT.format(question=question)
+        try:
+            response = model_eval.get_response_from_model(
+                model_name="gpt-3.5-turbo-0125", prompt=prompt, max_tokens=500, temperature=0
+            )
+            if "Classification:" not in response:
+                logger.error(f"'Classification:' is not in the response for question: {question}")
+                dfq.loc[index, "valid_question"] = None
+            else:
+                end_resp = response.split("Classification:")[1]
+                if "ok" in end_resp:
+                    dfq.loc[index, "valid_question"] = True
+                elif "flag" in end_resp:
+                    dfq.loc[index, "valid_question"] = False
+                    invalid_questions += [question]
+                    logger.info(f"The following question is ill-defined: {question}")
+                else:
+                    dfq.loc[index, "valid_question"] = True
+                    logger.error(f"Ambiguous response for question: {question}")
+        except Exception as e:
+            logger.error(f"Error in assign_category: {e}")
+            dfq.loc[index, "valid_question"] = True
+    dfq.loc[:, "valid_question"] = dfq["valid_question"].apply(
+        lambda x: x if x in [True, False] else ""
+    )
+    if invalid_questions:
+        logger.warning(f"Invalid_questions found:\n\n{'\n'.join(invalid_questions)}\n")
+    return dfq
+
+
+@decorator.log_runtime
+def driver(_):
+    """Pull in fetched data and update question metadata in question bank."""
+    local_filename = f"/tmp/{constants.META_DATA_FILENAME}"
+    dfmeta = data_utils.download_and_read(
+        filename=constants.META_DATA_FILENAME,
+        local_filename=local_filename,
+        df_tmp=pd.DataFrame(columns=constants.META_DATA_FILE_COLUMNS).astype(
+            constants.META_DATA_FILE_COLUMN_DTYPE
+        ),
+        dtype=constants.META_DATA_FILE_COLUMN_DTYPE,
+    )
+    if "valid_question" not in dfmeta.columns:
+        dfmeta["valid_question"] = ""
+    n_total_invalid = 0
+    for source, _ in constants.FREEZE_QUESTION_SOURCES.items():
+        logger.info(f"Validating {source} questions.")
+        dfq = data_utils.get_data_from_cloud_storage(
+            source=source,
+            return_question_data=True,
+        )
+        dfq["source"] = source
+
+        dfq = dfq.merge(dfmeta, on=["source", "id"], how="left").fillna("")
+        dfmeta = dfmeta[dfmeta["source"] != source]
+
+        if source in constants.DATA_SOURCES + [
+            "infer",
+            "metaculus",
+        ]:
+            dfq["valid_question"] = True
+        else:
+            dfq = validate_questions(dfq)
+
+        dfq = dfq[constants.META_DATA_FILE_COLUMNS]
+        dfq = dfq[dfq["valid_question"] != ""]
+        dfq["valid_question"] = dfq["valid_question"].astype(bool)
+        dfmeta = pd.concat(
+            [
+                dfmeta,
+                dfq,
+            ],
+            ignore_index=True,
+        )
+        n_false = len(dfq[~dfq["valid_question"]])
+        n_total_invalid += n_false
+
+        # Upload after every source is finished to save work
+        dfmeta.sort_values(by=["source", "id"], ignore_index=True, inplace=True)
+        dfmeta.to_json(local_filename, lines=True, orient="records")
+        logger.info(f"Uploading metadata for {source}. Total of {n_false} invalid questions.")
+        gcp.storage.upload(
+            bucket_name=constants.BUCKET_NAME,
+            local_filename=local_filename,
+        )
+    logger.info(f"Total of {n_total_invalid} invalid questions.")
+    logger.info("Done.")
+
+    return "OK", 200
+
+
+if __name__ == "__main__":
+    driver(None)

--- a/src/metadata/validate_questions/requirements.txt
+++ b/src/metadata/validate_questions/requirements.txt
@@ -1,0 +1,7 @@
+google-cloud-storage
+google-cloud-secret-manager
+pandas
+anthropic
+google-generativeai
+openai
+together

--- a/src/workflow/step2.yaml
+++ b/src/workflow/step2.yaml
@@ -18,7 +18,7 @@ main:
                   result: api_response_categorize
               - save_successful_categorize:
                   assign:
-                    - execution_results.success["fetch"]: True
+                    - execution_results.success["categorize"]: True
         retry: ${http.default_retry}
         except:
           as: e
@@ -29,6 +29,31 @@ main:
                     - execution_results.success["categorize"]: False
                     - execution_results.exception["categorize"]: ${e}
               - raise_categorize_exception:
+                  raise: ${execution_results}
+    - validate_questions:
+        try:
+          steps:
+              - call_metadata_validate_questions:
+                  call: http.post
+                  args:
+                      url: https://SUBDOMAIN.cloudfunctions.net/metadata_validate_questions
+                      auth:
+                           type: OIDC
+                      timeout: 1800
+                  result: api_response_validate_questions
+              - save_successful_validate_questions:
+                  assign:
+                    - execution_results.success["validate_questions"]: True
+        retry: ${http.default_retry}
+        except:
+          as: e
+          steps:
+              - save_failed_validate_questions:
+                  assign:
+                    - execution_results.failure: True
+                    - execution_results.success["validate_questions"]: False
+                    - execution_results.exception["validate_questions"]: ${e}
+              - raise_validate_questions_exception:
                   raise: ${execution_results}
     - check_exception_encountered:
         switch:


### PR DESCRIPTION
For each question set, validate only those questions that have not already been validated.

Only filter unreliable sources of questions. At the moment, this is just Manifold, but will add Polymarket when it comes in.

Save work after each source has been evaluated. Rerun the workflow on error.

issue #21