### PR TITLE
infer: fix bug

### DIFF
--- a/src/questions/infer/fetch/main.py
+++ b/src/questions/infer/fetch/main.py
@@ -109,12 +109,7 @@ def get_data(current_data):
     all_binary_questions = [
         q
         for q in all_active_questions
-        if q["state"] == "active"
-        and (
-            len(q["answers"]) == 2
-            and {q["answers"][0]["name"], q["answers"][1]["name"]} == {"No", "Yes"}
-        )
-        or (len(q["answers"]) == 1 and q["answers"][0]["name"] == "Yes")
+        if q["state"] == "active" and q["type"] == "Forecast::YesNoQuestion"
     ]
 
     # Convert all_new_questions to a set of IDs for faster lookup


### PR DESCRIPTION
The previous way of determining binary questions was not correct.

It obtained questions that were of non-binary types or of type "continuous binary" but we cannot resolve these correctly.

The possible types are:
[
'Forecast::Binary::ContinuousQuestion',
'Forecast::ContinuousYesNoQuestion',
'Forecast::NonExclusiveOpinionPoolQuestion',
'Forecast::Question',
'Forecast::YesNoQuestion'
]

Of these, the only type we're interested in are of type `'Forecast::YesNoQuestion'`