### PR TITLE
fix: strip duplicated resolution frame validation

### DIFF
--- a/src/sources/infer.py
+++ b/src/sources/infer.py
@@ -386,14 +386,14 @@ class InferSource(MarketSource):
 
     @staticmethod
     def _finalize_resolution_df(df: pd.DataFrame) -> DataFrame[ResolutionFrame]:
-        """Apply date filtering and return as validated ResolutionFrame.
+        """Apply date filtering and select resolution columns.
 
         Args:
             df (pd.DataFrame): Raw resolution data with id, date, value columns.
         """
         df["date"] = pd.to_datetime(df["date"])
         df = df[df["date"].dt.date >= constants.BENCHMARK_START_DATE_DATETIME_DATE]
-        return ResolutionFrame.validate(df[["id", "date", "value"]])
+        return df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
 
     # ------------------------------------------------------------------
     # Private: question transformation

--- a/src/sources/manifold.py
+++ b/src/sources/manifold.py
@@ -407,11 +407,10 @@ class ManifoldSource(MarketSource):
 
     @staticmethod
     def _finalize_resolution_df(df: pd.DataFrame) -> DataFrame[ResolutionFrame]:
-        """Filter to benchmark period and validate as ResolutionFrame."""
+        """Filter to benchmark period and select resolution columns."""
         df["date"] = pd.to_datetime(df["date"])
         df = df[df["date"].dt.date >= constants.BENCHMARK_START_DATE_DATETIME_DATE]
-        df = df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
-        return ResolutionFrame.validate(df)
+        return df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
 
     @staticmethod
     def _get_resolved_market_value(market: dict) -> float:

--- a/src/sources/metaculus.py
+++ b/src/sources/metaculus.py
@@ -446,7 +446,7 @@ class MetaculusSource(MarketSource):
 
     @staticmethod
     def _finalize_resolution_df(df: pd.DataFrame) -> DataFrame[ResolutionFrame]:
-        """Cast types and return as a validated ResolutionFrame.
+        """Cast types and select resolution columns.
 
         Unlike infer/manifold, Metaculus does not filter to the benchmark start date:
         the aggregation history is already bounded by the question's open window, and
@@ -455,5 +455,4 @@ class MetaculusSource(MarketSource):
         Args:
             df (pd.DataFrame): Raw resolution data with id, date, value columns.
         """
-        df = df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
-        return ResolutionFrame.validate(df)
+        return df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)

--- a/src/sources/polymarket.py
+++ b/src/sources/polymarket.py
@@ -547,4 +547,4 @@ class PolymarketSource(MarketSource):
         df = pd.DataFrame(question["historical_prices"])
         df["id"] = question["id"]
         df = df[["id", "date", "value"]].astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
-        return ResolutionFrame.validate(df)
+        return df


### PR DESCRIPTION
fixes #206 

also happens to fix a dormant deviation for infer: original infer refactor [stripped infer's](https://github.com/forecastingresearch/forecastbench/commit/2594813d38d3e58f0f3a927c0016aa778b1745aa#diff-54049b12d5a7c1ea319b2d3d2d20287f3e4db72b3d19e1386870a1fa24328021L165) `astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)` when building the resolution frame. Is now corrected and matches manifold/metaculus.

Let me know if I should run parity tests for all 3 sources - I will assume not.