### PR TITLE
fix: delete `probability` in yfinance fetch

### DIFF
--- a/src/_schemas.py
+++ b/src/_schemas.py
@@ -117,10 +117,9 @@ class PolymarketFetchFrame(QuestionFrame):
 
 
 class YfinanceFetchFrame(QuestionFrame):
-    """Output of YfinanceSource.fetch(). QuestionFrame plus transient fields for update()."""
+    """Output of YfinanceSource.fetch(). QuestionFrame plus a transient field for update()."""
 
     fetch_datetime: Series[str]
-    probability: Series[object] = pa.Field(nullable=True)
 
 
 class ManifoldFetchFrame(pa.DataFrameModel):

--- a/src/sources/yfinance.py
+++ b/src/sources/yfinance.py
@@ -101,7 +101,6 @@ class YfinanceSource(DatasetSource):
                         "resolved": False,
                         "market_info_resolution_datetime": "N/A",
                         "fetch_datetime": current_time,
-                        "probability": current_price,
                         "forecast_horizons": constants.FORECAST_HORIZONS_IN_DAYS,
                         "freeze_datetime_value": current_price,
                         "freeze_datetime_value_explanation": (
@@ -122,7 +121,6 @@ class YfinanceSource(DatasetSource):
                     {
                         "resolved": True,
                         "fetch_datetime": current_time,
-                        "probability": float("nan"),
                         "freeze_datetime_value": "N/A",
                     }
                 )
@@ -185,7 +183,6 @@ class YfinanceSource(DatasetSource):
 
             # Strip transient fetch-only fields (not part of QuestionFrame)
             del question["fetch_datetime"]
-            del question["probability"]
 
             # Upsert into dfq
             if question["id"] in dfq["id"].values:

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -306,7 +306,6 @@ def make_yfinance_fetch_df(rows):
         "market_info_close_datetime": "N/A",
         "market_info_resolution_datetime": "N/A",
         "fetch_datetime": "2026-03-18T00:00:00+00:00",
-        "probability": 100.0,
     }
     df = pd.DataFrame(rows)
     for col, default in defaults.items():

--- a/src/tests/test_yfinance.py
+++ b/src/tests/test_yfinance.py
@@ -299,7 +299,7 @@ class TestSourceFetch:
         row = dff[dff["id"] == "AAPL"].iloc[0]
         assert bool(row["resolved"]) is False
         assert row["url"] == "https://finance.yahoo.com/quote/AAPL"
-        assert float(row["probability"]) == 254.23
+        assert float(row["freeze_datetime_value"]) == 254.23
 
     @patch("sources.yfinance.yf.Ticker")
     @patch.object(YfinanceSource, "_get_sp500_tickers", return_value=[])
@@ -316,7 +316,6 @@ class TestSourceFetch:
         row = dff[dff["id"] == "OLDCO"].iloc[0]
         assert bool(row["resolved"]) is True
         assert row["freeze_datetime_value"] == "N/A"
-        assert pd.isna(row["probability"])
         assert row["question"] == "legacy question"  # original question text preserved
 
     @patch("sources.yfinance.yf.Ticker")
@@ -539,7 +538,6 @@ class TestSourceUpdate:
                     "background": "Hess Corporation.",
                     "resolved": True,
                     "freeze_datetime_value": "N/A",
-                    "probability": float("nan"),
                 }
             ]
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the obsolete `probability` field from Yfinance fetch/update outputs to align with the current results contract.
  * Updated delisted-ticker flow so resolved records keep the expected question data and `freeze_datetime_value` behavior after the field removal.
* **Tests**
  * Updated test fixtures and assertions to stop expecting `probability`, while continuing to validate `freeze_datetime_value` and resolved-row contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->