### PR TITLE
fix: add retry on polymarket's `_get_market` so a transient server error does not break the job

### DIFF
--- a/src/sources/polymarket.py
+++ b/src/sources/polymarket.py
@@ -291,6 +291,12 @@ class PolymarketSource(MarketSource):
 
         return all_markets
 
+    @backoff.on_exception(
+        backoff.expo,
+        requests.exceptions.RequestException,
+        max_time=20,
+        on_backoff=data_utils.print_error_info_handler,
+    )
     def _get_market(self, condition_id: str) -> dict:
         """Fetch a single market by condition ID, trying open then closed markets.
 

--- a/src/tests/test_polymarket.py
+++ b/src/tests/test_polymarket.py
@@ -564,15 +564,22 @@ class TestGetMarket:
         with pytest.raises(ConditionIdMarketNotFoundError):
             polymarket_source._get_market("0x001")
 
+    @patch("sources.polymarket.time.sleep")
     @patch("sources.polymarket.requests.get")
-    def test_http_error_propagates(self, mock_get, polymarket_source):
-        """An HTTP error is not swallowed — it propagates."""
-        resp = Mock()
-        resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
-        mock_get.return_value = resp
+    def test_transient_error_then_success(self, mock_get, _mock_sleep, polymarket_source):
+        """A transient HTTP error (e.g. a 500 blip) is retried via backoff and then succeeds."""
+        market = make_polymarket_api_market()
+        err_resp = Mock()
+        err_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500")
+        mock_get.side_effect = [
+            err_resp,  # first attempt: transient 500
+            self._mock_response([market]),  # retry: open-market match
+        ]
 
-        with pytest.raises(requests.exceptions.HTTPError):
-            polymarket_source._get_market("0xabc123")
+        result = polymarket_source._get_market("0xabc123")
+
+        assert result == market
+        assert mock_get.call_count == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved market lookup reliability by retrying temporary request failures with exponential backoff.
  * Reduced failed lookups from brief API/network interruptions.

* **Tests**
  * Updated automated coverage to confirm lookups retry after an initial HTTP error and succeed on a later attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->