### PR TITLE
feat: add slack warning for 404 fetches

### DIFF
--- a/src/orchestration/func_yfinance_fetch/main.py
+++ b/src/orchestration/func_yfinance_fetch/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from helpers import data_utils, decorator
+from helpers import data_utils, decorator, slack
 from orchestration import _source_io
 from sources.yfinance import YfinanceSource
 
@@ -13,6 +13,23 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 SOURCE = "yfinance"
+
+
+def _alert_uncurated_delisted(tickers: list[str]) -> None:
+    """Slack alert for pooled tickers that 404'd but aren't curated.
+
+    They are either newly delisted or newly renamed and need prompt triage into
+    nullified_questions or ticker_renames (a rename left uncurated resolves old questions to stale
+    prices).
+    """
+    message = (
+        f":warning: yfinance fetch: {len(tickers)} ticker(s) failed to fetch and are no longer in "
+        f"the S&P 500 (likely delisted or renamed): {', '.join(tickers)}. "
+        "If delisted, add to nullified_questions; if renamed, add to ticker_renames "
+        "(mapping to the replacement symbol)."
+    )
+    logger.warning(message)
+    slack.send_message(message=message)
 
 
 @decorator.log_runtime
@@ -25,6 +42,10 @@ def driver(_: Any) -> None:
     dff = source.fetch(dfq=dfq)
 
     _source_io.write_fetch_output(SOURCE, dff)
+
+    if source.uncurated_delisted_tickers:
+        _alert_uncurated_delisted(source.uncurated_delisted_tickers)
+
     logger.info("Done.")
 
 

--- a/src/orchestration/func_yfinance_fetch/requirements.txt
+++ b/src/orchestration/func_yfinance_fetch/requirements.txt
@@ -1,4 +1,6 @@
 google-cloud-storage
+google-cloud-secret-manager
+slack_sdk
 pandas>=2.2.2,<3.0
 pandera
 requests

--- a/src/sources/yfinance.py
+++ b/src/sources/yfinance.py
@@ -103,6 +103,9 @@ class YfinanceSource(DatasetSource):
         current_time = dates.get_datetime_now()
 
         rows = []
+        # Pooled tickers that 404 this run but aren't curated (neither nullified nor renamed).
+        # Recorded so the driver can surface them (e.g. via Slack) for triage into the right list.
+        self.uncurated_delisted_tickers: list[str] = []
 
         # Carry forward known-unfetchable tickers (nullified + renamed originals) without the API.
         for ticker_symbol in carry_forward_ids:
@@ -148,13 +151,15 @@ class YfinanceSource(DatasetSource):
                 and ticker_symbol in set_current
                 and ticker_symbol not in set_top_500
             ):
-                # Newly delisted: still in the question pool but no longer fetchable and out of
-                # the S&P 500, yet not in the curated nullified list. Carry the existing question
-                # row forward as resolved and warn so it can be added to nullified_questions.
+                # In the question pool, no longer fetchable, and out of the S&P 500, but not in any
+                # curated list: either newly delisted or newly renamed. Carry the existing row
+                # forward as resolved and record it so the driver can flag it for triage.
                 rows.append(self._carry_forward_resolved(ticker_symbol, dfq, current_time))
+                self.uncurated_delisted_tickers.append(ticker_symbol)
                 logger.warning(
-                    f"{ticker_symbol} detected as delisted (not in S&P 500 and fetch failed); "
-                    "consider adding it to nullified_questions"
+                    f"{ticker_symbol} failed to fetch and is no longer in the S&P 500 (likely "
+                    "delisted or renamed). If delisted, add it to nullified_questions; if renamed, "
+                    "add it to ticker_renames (mapping it to its replacement symbol)."
                 )
 
         return pd.DataFrame(rows)

--- a/src/tests/test_yfinance.py
+++ b/src/tests/test_yfinance.py
@@ -355,6 +355,27 @@ class TestSourceFetch:
         outco = dff[dff["id"] == "OUTCO"].iloc[0]
         assert bool(outco["resolved"]) is False
 
+    @patch("sources.yfinance.yf.Ticker")
+    @patch.object(YfinanceSource, "_fetch_one_stock")
+    @patch.object(YfinanceSource, "_get_sp500_tickers", return_value=["AAPL"])
+    def test_records_uncurated_delisted_for_triage(
+        self, _mock_tickers, mock_fetch_one, mock_ticker_cls, yfinance_source, freeze_today
+    ):
+        """A pooled ticker that 404s but isn't curated is recorded for triage; nullified/renamed
+        tickers (carried forward without fetching) are not."""
+        freeze_today(date(2026, 3, 18))
+        hist = pd.DataFrame({"Close": [254.23], "Date": pd.to_datetime(["2026-03-17"])})
+        mock_fetch_one.side_effect = lambda sym: (
+            ("Apple Inc.", hist) if sym == "AAPL" else (None, None)
+        )
+        mock_ticker_cls.return_value.info.get.return_value = "N/A"
+
+        # ZZZZ: uncurated 404. WBA: nullified. FI: renamed original. Only ZZZZ is for triage.
+        dfq = make_question_df([{"id": "AAPL"}, {"id": "ZZZZ"}, {"id": "WBA"}, {"id": "FI"}])
+        yfinance_source.fetch(dfq=dfq)
+
+        assert yfinance_source.uncurated_delisted_tickers == ["ZZZZ"]
+
 
 class TestSourceFetchSkipsNullified:
     """Nullified (known-delisted) tickers are never fetched, only carried forward."""


### PR DESCRIPTION
renames are super time-sensitive as they could to incorrect resolutions if not added to the list

on top of #227 