### PR TITLE
WIP: push resolution sets to git in a single commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ orchestration: nightly-worker-job nightly-manager-job compress_buckets
 
 metadata: tag-questions validate-questions
 
-resolve: resolve-forecasts
+resolve: resolve-forecasts push-resolution-sets
 
 leaderboards: leaderboard-tournament leaderboard-baseline leaderboard-preliminary
 
@@ -204,6 +204,9 @@ validate-questions:
 
 resolve-forecasts:
 	$(MAKE) -C src/orchestration/func_resolve || echo "* $@" >> $(MAKE_FAILURE_LOG)
+
+push-resolution-sets:
+	$(MAKE) -C src/orchestration/func_push_resolution_sets || echo "* $@" >> $(MAKE_FAILURE_LOG)
 
 naive-and-dummy-forecasters:
 	$(MAKE) -C src/base_eval/naive_and_dummy_forecasters || echo "* $@" >> $(MAKE_FAILURE_LOG)

--- a/src/helpers/git.py
+++ b/src/helpers/git.py
@@ -84,6 +84,15 @@ def clone_and_push_files(
         shutil.copy(source, full_destination_path, follow_symlinks=False)
         repo.index.add([destination])
 
+    # Skip the commit/push if none of the staged files differ from what's already in the repo.
+    # This avoids empty commits: the resolution-set push job re-adds every resolution set every
+    # night, but on nights where nothing changed there is nothing to commit.
+    if not repo.index.diff(repo.head.commit):
+        logger.info(f"No changes to push to {repo_url}; skipping commit.")
+        os.remove(tmp_key_file_path)
+        shutil.rmtree(local_repo_dir, ignore_errors=True)
+        return
+
     error_encountered = False
     author = Actor("ForecastBench bot", constants.BENCHMARK_EMAIL)
     committer = Actor("ForecastBench bot", constants.BENCHMARK_EMAIL)

--- a/src/nightly_update_workflow/manager/main.py
+++ b/src/nightly_update_workflow/manager/main.py
@@ -181,12 +181,26 @@ def main():
         dict_to_use=dict_to_use_naive_and_dummy_forecasters, task_count=1
     )
 
-    # Block on resolve forecasts before launching leaderboards
+    # Block on resolve forecasts before pushing resolution sets to git
     cloud_run.block_and_check_job_result(
         operation=operation_resolve_forecasts,
         name=dict_to_use_resolve_forecasts,
         exit_on_error=True,
         timeout=timeout_resolve_forecasts,
+    )
+
+    # Push all resolution sets to git in a single commit, now that every (parallel) resolve task
+    # has finished uploading its resolution set to the bucket. Done as its own job so that only
+    # one process clones and pushes to the dataset repo, avoiding a race condition.
+    dict_to_use_push_resolution_sets = "push_resolution_sets"
+    operation_push_resolution_sets = call_worker(
+        dict_to_use=dict_to_use_push_resolution_sets,
+        task_count=1,
+    )
+    cloud_run.block_and_check_job_result(
+        operation=operation_push_resolution_sets,
+        name=dict_to_use_push_resolution_sets,
+        exit_on_error=False,
     )
 
     # Launch leaderboard jobs in parallel

--- a/src/nightly_update_workflow/worker/main.py
+++ b/src/nightly_update_workflow/worker/main.py
@@ -17,6 +17,15 @@ resolve_forecasts = [
         ("func-resolve-forecasts", True, cloud_run.timeout_1h * 3, 50),
     ]
 ]
+
+
+push_resolution_sets = [
+    [
+        ("func-push-resolution-sets", True, cloud_run.timeout_1h, 1),
+    ]
+]
+
+
 leaderboards = [
     [
         ("func-leaderboard-tournament", True, cloud_run.timeout_1h * 4, 1),
@@ -139,7 +148,8 @@ def main():
 
     Env variables:
     CLOUD_RUN_TASK_INDEX: automatically set by Cloud Run Jobs
-    DICT_TO_USE: one of `fetch_and_update`, `metadata`, `resolve_forecasts`, `leaderboards`.
+    DICT_TO_USE: one of `fetch_and_update`, `metadata`, `resolve_forecasts`,
+                 `push_resolution_sets`, `leaderboards`.
     """
     dict_mapping = {
         "fetch_and_update": get_fetch_and_update(),
@@ -147,6 +157,7 @@ def main():
         "create_question_set": get_create_question_set(),
         "publish_question_set_make_llm_baseline": get_publish_question_set_make_llm_baseline(),
         "resolve_forecasts": resolve_forecasts,
+        "push_resolution_sets": push_resolution_sets,
         "leaderboards": leaderboards,
         "naive_and_dummy_forecasters": get_naive_and_dummy_forecasters(),
         "website": website,

--- a/src/orchestration/_io.py
+++ b/src/orchestration/_io.py
@@ -223,9 +223,13 @@ def upload_hash_mapping(raw_json: str, source_name: str) -> None:
 
 
 def upload_resolution_set(df: pd.DataFrame, forecast_due_date: str, question_set_filename: str):
-    """Upload resolution set to GCS and push to git."""
-    from helpers import git  # noqa: E402
+    """Upload resolution set to GCS.
 
+    The resolution set is only uploaded to the bucket here. Pushing the resolution sets to git
+    happens later in a single commit via `push_all_resolution_sets`, run as its own Cloud Run job
+    once all (parallel) resolution tasks have finished. This avoids the race condition that
+    occurred when each parallel task cloned and pushed to the git repository independently.
+    """
     basename = f"{forecast_due_date}_resolution_set.json"
     local_filename = f"/tmp/{basename}"
     df = df[["id", "source", "direction", "resolution_date", "resolved_to", "resolved"]]
@@ -248,14 +252,53 @@ def upload_resolution_set(df: pd.DataFrame, forecast_due_date: str, question_set
     )
     logger.info(f"Uploaded Resolution File {local_filename} to {upload_folder}.")
 
+
+def push_all_resolution_sets() -> None:
+    """Push every resolution set in the bucket to the git dataset repo in a single commit.
+
+    The parallel resolution tasks each upload their resolution set to `PUBLIC_RELEASE_BUCKET`
+    (see `upload_resolution_set`). This function gathers all of those files and pushes them to
+    git in one commit, so only a single process ever clones and pushes to the repository. This
+    removes the race condition that arose when each parallel task pushed independently.
+    """
+    from helpers import git  # noqa: E402
+
+    if env.RUNNING_LOCALLY:
+        logger.info("Running locally; not pushing resolution sets to git.")
+        return
+
+    folder = "datasets/resolution_sets"
+    blob_names = gcp.storage.list_with_prefix(
+        bucket_name=env.PUBLIC_RELEASE_BUCKET,
+        prefix=folder,
+    )
+
+    files = {}
+    for blob_name in blob_names:
+        basename = os.path.basename(blob_name)
+        if not basename.endswith("_resolution_set.json"):
+            continue
+        local_filename = f"/tmp/{basename}"
+        gcp.storage.download(
+            bucket_name=env.PUBLIC_RELEASE_BUCKET,
+            filename=blob_name,
+            local_filename=local_filename,
+        )
+        files[local_filename] = f"{folder}/{basename}"
+
+    if not files:
+        logger.warning(f"No resolution sets found under {folder}; nothing to push.")
+        return
+
     mirrors = keys.get_secret_that_may_not_exist("HUGGING_FACE_REPO_URL")
     mirrors = [mirrors] if mirrors else []
     git.clone_and_push_files(
         repo_url=keys.API_GITHUB_DATASET_REPO_URL,
-        files={local_filename: f"{upload_folder}/{basename}"},
-        commit_message=f"resolution set: automatic update for {question_set_filename}.",
+        files=files,
+        commit_message="resolution sets: automatic update.",
         mirrors=mirrors,
     )
+    logger.info(f"Pushed {len(files)} resolution sets to git in a single commit.")
 
 
 def upload_processed_forecast_file(data: dict, forecast_due_date: str, filename: str):

--- a/src/orchestration/func_push_resolution_sets/Makefile
+++ b/src/orchestration/func_push_resolution_sets/Makefile
@@ -1,0 +1,46 @@
+all :
+	$(MAKE) clean
+	$(MAKE) deploy
+
+.PHONY : all clean deploy
+
+UPLOAD_DIR = upload
+
+.gcloudignore:
+	cp -r $(ROOT_DIR)src/helpers/.gcloudignore .
+
+Dockerfile: $(ROOT_DIR)src/helpers/Dockerfile.template
+	sed \
+		-e 's/REGION/$(CLOUD_DEPLOY_REGION)/g' \
+		-e 's/STACK/google-22-full/g' \
+		-e 's/PYTHON_VERSION/python312/g' \
+		$< > Dockerfile
+
+NUM_CPUS = 1
+
+deploy : main.py .gcloudignore requirements.txt Dockerfile
+	mkdir -p $(UPLOAD_DIR)
+	cp -r $(ROOT_DIR)utils $(UPLOAD_DIR)/
+	cp -r $(ROOT_DIR)src/helpers $(UPLOAD_DIR)/helpers
+	cp -r $(ROOT_DIR)src/sources $(UPLOAD_DIR)/sources
+	mkdir -p $(UPLOAD_DIR)/orchestration
+	cp $(ROOT_DIR)src/orchestration/__init__.py $(UPLOAD_DIR)/orchestration/
+	cp $(ROOT_DIR)src/orchestration/_io.py $(UPLOAD_DIR)/orchestration/
+	cp $(ROOT_DIR)src/_fb_types.py $(UPLOAD_DIR)/
+	cp $(ROOT_DIR)src/_schemas.py $(UPLOAD_DIR)/
+	cp $^ $(UPLOAD_DIR)/
+	gcloud run jobs deploy \
+		func-push-resolution-sets \
+		--project $(CLOUD_PROJECT) \
+		--region $(CLOUD_DEPLOY_REGION) \
+		--tasks 1 \
+		--task-timeout 1h \
+		--memory 2Gi \
+		--cpu $(NUM_CPUS) \
+		--max-retries 0 \
+		--service-account $(QUESTION_BANK_BUCKET_SERVICE_ACCOUNT) \
+		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS),NUM_CPUS=$(NUM_CPUS) \
+		--source $(UPLOAD_DIR)
+
+clean :
+	rm -rf $(UPLOAD_DIR) .gcloudignore Dockerfile

--- a/src/orchestration/func_push_resolution_sets/main.py
+++ b/src/orchestration/func_push_resolution_sets/main.py
@@ -1,0 +1,27 @@
+"""Push all resolution sets to the git dataset repo in a single commit.
+
+This runs as its own Cloud Run job after the (parallel) resolve-forecasts tasks have finished.
+Each resolve task uploads its resolution set to the bucket only; this job gathers all of them
+and pushes them to git in a single commit, so that only one process ever clones and pushes to
+the dataset repository. This removes the race condition that occurred when each parallel task
+pushed independently. See `orchestration._io.push_all_resolution_sets`.
+"""
+
+import logging
+from typing import Any
+
+from helpers import decorator
+from orchestration import _io
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+@decorator.log_runtime
+def driver(_: Any) -> None:
+    """Push all resolution sets to git in a single commit."""
+    _io.push_all_resolution_sets()
+
+
+if __name__ == "__main__":
+    driver(None)

--- a/src/orchestration/func_push_resolution_sets/requirements.txt
+++ b/src/orchestration/func_push_resolution_sets/requirements.txt
@@ -1,0 +1,13 @@
+google-cloud-storage
+google-cloud-secret-manager
+pandas>=2.2.2,<3.0
+tqdm
+gcsfs==2025.7.0
+GitPython
+scipy
+termcolor
+slack_sdk
+pandera
+pytz
+python-dateutil
+backoff


### PR DESCRIPTION
New single-task Cloud Run job `func-push-resolution-sets` gathers all resolution sets from the bucket and pushes them in one commit, fixing the race condition from parallel resolve tasks pushing independently.

Still needs end-to-end testing in a GCP dev project.

Refs #148