### PR TITLE
fix: map renamed yfinance ticker `BK` -> `BNY`

### DIFF
--- a/src/sources/_metadata.py
+++ b/src/sources/_metadata.py
@@ -370,6 +370,7 @@ SOURCE_METADATA = {
         "ticker_renames": [
             {"original_ticker": "FI", "replacement_ticker": "FISV"},
             {"original_ticker": "MMC", "replacement_ticker": "MRSH"},
+            {"original_ticker": "BK", "replacement_ticker": "BNY"},
         ],
     },
 }

--- a/src/tests/test_yfinance.py
+++ b/src/tests/test_yfinance.py
@@ -35,6 +35,7 @@ class TestTickerRenamesDefinition:
         renames = {e["original_ticker"]: e["replacement_ticker"] for e in TICKER_RENAMES}
         assert renames["FI"] == "FISV"
         assert renames["MMC"] == "MRSH"
+        assert renames["BK"] == "BNY"
 
 
 class TestDelistedStocksDefinition:


### PR DESCRIPTION
https://www.bny.com/corporate/global/en/about-us/newsroom/press-release/bny-announces-planned-change-of-stock-ticker-symbol-to-bny-130465.html

Verified with:

```bash
python3 - <<'PY'
import json,urllib.request,datetime as dt
g=lambda s:json.load(urllib.request.urlopen(urllib.request.Request(
  f"https://query1.finance.yahoo.com/v8/finance/chart/{s}?range=6mo&interval=1d",
  headers={"User-Agent":"Mozilla/5.0"})))["chart"]["result"][0]
d=lambda t:dt.datetime.utcfromtimestamp(t).date()
for s in ("BK","BNY"):
    r=g(s); m=r["meta"]
    bars=[(d(t),c) for t,c in zip(r.get("timestamp") or [],
          r["indicators"]["quote"][0].get("close") or []) if c is not None]
    print(f"{s}: {len(bars)} bars {bars[0][0]}..{bars[-1][0]} | "
          f"last real trade {d(m['regularMarketTime'])} @ {m['regularMarketPrice']} | "
          f"firstTradeDate {d(m['firstTradeDate'])}")
PY
```

Output:
```
BK:  1 bars   2026-07-10..2026-07-10 | last real trade 2026-05-20 @ 137.16 | firstTradeDate 2026-07-10
BNY: 123 bars 2026-01-14..2026-07-13 | last real trade 2026-07-13 @ 151.27 | firstTradeDate 1973-05-03
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated ticker handling so the yfinance source recognizes `BK` as the previous ticker for `BNY`.

* **Tests**
  * Added coverage to verify the new ticker rename mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->