### PR TITLE
fix: nullify bogus wikipedia "Jonny Liette" swimming question

### DIFF
--- a/src/sources/_metadata.py
+++ b/src/sources/_metadata.py
@@ -320,6 +320,14 @@ SOURCE_METADATA = {
                 id="c6ee39b4504603aa5ddbe73f378d48d94ab128406e5dd1bbb70ead0207a43840",
                 nullification_start_date=date(2025, 7, 30),
             ),  # noqa: B950
+            # Non-existent swimmer "Jonny Liette" — fabricated 50m backstroke WR question. The name
+            # is not a real record holder (the men's 50m backstroke WR is held by Kliment
+            # Kolesnikov, 23.55) and never appeared in the source article's revision history.
+            # Nullify from the benchmark start so it is never sampled and resolves to null.
+            NullifiedQuestion(
+                id="135a1523e67a012ce700a810c8c0c152a5bc6f0f01303ffe7ae28daf9ba4aa7c",
+                nullification_start_date=BENCHMARK_START_DATE_DATETIME_DATE,
+            ),  # noqa: B950
         ],
     },
     "yfinance": {


### PR DESCRIPTION
- no mention on the original wiki article: https://en.wikipedia.org/wiki/List_of_world_records_in_swimming
- no mention of Jonny Liette on wikipedia: https://en.wikipedia.org/w/index.php?search=%22Jonny+Liette%22&fulltext=1&ns0=1
- no record of Liette on wikiblame: https://wikipedia.ramselehof.de/wikiblame.php?user_lang=en&lang=en&project=wikipedia&tld=org&article=List+of+world+records+in+swimming&needle=Liette&skipversions=0&ignorefirst=0&limit=500&offmon=7&offtag=14&offjahr=2026&searchmethod=int&order=desc&user=

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of questions tied to an invalid or non-existent swimmer record.
  - Such questions now resolve to no result starting from the benchmark period, preventing fabricated information from being returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->