### PR TITLE
feat: support URLs in forecast submissions

### DIFF
--- a/src/orchestration/_io.py
+++ b/src/orchestration/_io.py
@@ -37,6 +37,14 @@ DATASETS_QUESTION_SETS_RAW_BASE_URL = (
 )
 QUESTION_SET_READ_TIMEOUT_SECONDS = 30
 
+# Submissions with a forecast due date on or after this date must provide a `url`
+# field with the submitting organization's website, unless the submission is
+# anonymous. Forecast sets due before this date predate the requirement and are
+# still processed without one.
+URL_REQUIRED_AS_OF_DUE_DATE = "2026-08-01"
+
+ANONYMOUS_ORGANIZATION_RE = re.compile(r"^anonymous(\s+\d+)?$", re.IGNORECASE)
+
 
 # ---------------------------------------------------------------------------
 # Question bank loading
@@ -457,6 +465,10 @@ def get_valid_forecast_files_and_dates(
 def read_forecast_file(filename: str, f: TextIO | None = None) -> dict | None:
     """Read a forecast JSON file and validate its content.
 
+    The optional `url` field, when present, must be an http(s) URL. It is required
+    for non-anonymous submissions with a forecast due date on or after
+    URL_REQUIRED_AS_OF_DUE_DATE.
+
     Args:
         filename: Path to the forecast JSON file.
         f: Open file handle. If None, filename will be opened.
@@ -488,6 +500,32 @@ def read_forecast_file(filename: str, f: TextIO | None = None) -> dict | None:
         logger.error(
             colored(
                 f"Problem processing {filename}. Issue with question set filename: {question_set}",
+                "yellow",
+            )
+        )
+        return None
+
+    url = data.get("url")
+    if url is not None and (
+        not isinstance(url, str) or not url.startswith(("http://", "https://"))
+    ):
+        logger.error(
+            colored(
+                f"Problem processing {filename}. `url` must be an http(s) URL, got: {url}.",
+                "yellow",
+            )
+        )
+        return None
+
+    if (
+        not url
+        and forecast_due_date >= URL_REQUIRED_AS_OF_DUE_DATE
+        and not ANONYMOUS_ORGANIZATION_RE.match(organization.strip())
+    ):
+        logger.error(
+            colored(
+                f"Problem processing {filename}. Missing required field `url`; it is "
+                "required for non-anonymous submissions.",
                 "yellow",
             )
         )

--- a/src/orchestration/func_resolve/main.py
+++ b/src/orchestration/func_resolve/main.py
@@ -42,6 +42,7 @@ FORECAST_FILE_METADATA_FIELDS = [
     "model_run_slug",
     "forecast_variant_key",
     "uses_freeze_values",
+    "url",
 ]
 
 

--- a/src/tests/orchestration/test_forecast_file_io.py
+++ b/src/tests/orchestration/test_forecast_file_io.py
@@ -1,9 +1,68 @@
 """Tests for processed forecast file IO."""
 
+import io
 import json
 
 from helpers import env
 from orchestration import _io
+
+
+def _forecast_file_handle(**overrides) -> io.StringIO:
+    """Return a file handle for a forecast submission with sensible defaults."""
+    data = {
+        "organization": "Test Org",
+        "model": "Test Model",
+        "model_organization": "Test Model Org",
+        "question_set": "2026-09-01-llm.json",
+        "forecasts": [{"id": "q1", "forecast": 0.5}],
+    }
+    data.update(overrides)
+    data = {k: v for k, v in data.items() if v is not None}
+    return io.StringIO(json.dumps(data))
+
+
+def test_read_forecast_file_passes_url_through():
+    data = _io.read_forecast_file(
+        "forecast.json",
+        f=_forecast_file_handle(url="https://example.org"),
+    )
+
+    assert data is not None
+    assert data["url"] == "https://example.org"
+
+
+def test_read_forecast_file_requires_url_for_new_non_anonymous_submissions():
+    data = _io.read_forecast_file("forecast.json", f=_forecast_file_handle())
+
+    assert data is None
+
+
+def test_read_forecast_file_allows_missing_url_for_anonymous_submissions():
+    data = _io.read_forecast_file(
+        "forecast.json",
+        f=_forecast_file_handle(organization="Anonymous 12"),
+    )
+
+    assert data is not None
+    assert "url" not in data
+
+
+def test_read_forecast_file_allows_missing_url_for_old_forecast_sets():
+    data = _io.read_forecast_file(
+        "forecast.json",
+        f=_forecast_file_handle(question_set="2026-05-24-llm.json"),
+    )
+
+    assert data is not None
+
+
+def test_read_forecast_file_rejects_non_http_url():
+    data = _io.read_forecast_file(
+        "forecast.json",
+        f=_forecast_file_handle(url="example.org"),
+    )
+
+    assert data is None
 
 
 def test_valid_forecast_files_excludes_nested_test_files(monkeypatch):


### PR DESCRIPTION
Closes #254

## What this does

Adds the `url` field to forecast submissions so organizations can provide their website directly in the submission file.

- `read_forecast_file()` (src/orchestration/_io.py) now reads and validates the field: when present it must be an http(s) URL, otherwise the file is rejected with a clear log line.
- **Required going forward, optional for history:** non-anonymous submissions whose forecast due date is on or after `URL_REQUIRED_AS_OF_DUE_DATE` (currently `2026-08-01`) are rejected if `url` is missing. Forecast sets due before that date keep processing without one, so nightly resolution of historical files is unaffected. Happy to adjust the cutoff date to whatever due date you want enforcement to start at.
- **Anonymous submissions are exempt** — organizations matching "Anonymous"/"Anonymous N" (same pattern the leaderboard uses) can omit the field.
- The field is passed through into the processed forecast set via `FORECAST_FILE_METADATA_FIELDS` in `func_resolve/main.py`. It is not surfaced anywhere on the website, per the issue.

## Tests

Five new contract tests in `src/tests/orchestration/test_forecast_file_io.py` covering: pass-through of a valid url, rejection of a new non-anonymous submission without url, anonymous exemption, old-forecast-set exemption, and rejection of a non-http(s) url.

`python -m pytest src/tests/orchestration/test_forecast_file_io.py` → 10/10 pass. `black --check`, `isort --check`, `flake8`, and `pydocstyle` (repo config) all clean on the changed files.

## Wiki

The [How to submit wiki page](https://github.com/forecastingresearch/forecastbench/wiki/How-does-ForecastBench-work%3F) can't be updated via PR; suggested addition to the submission-format section:

> `url` *(string, required for non-anonymous submissions)* — Your organization's website, e.g. `"https://example.org"`. Must start with `http://` or `https://`. Anonymous submissions may omit this field.