### PR TITLE
fix: handle stale Kalshi resolution windows after early settlement

### DIFF
--- a/src/sources/kalshi.py
+++ b/src/sources/kalshi.py
@@ -49,6 +49,7 @@ _MAX_CANDLESTICKS_PER_REQUEST = 5000
 _MAX_CANDLESTICK_RANGE_SECONDS = (
     (_MAX_CANDLESTICKS_PER_REQUEST - 1) * _CANDLESTICK_PERIOD_INTERVAL * 60
 )
+_POST_CLOSE_STATUSES = {"closed", "determined", "disputed", "amended", "finalized"}
 _RESOLVED_STATUSES = {"finalized"}
 _SETTLEMENT_SOURCE_PREFIX = "Outcome verified from "
 
@@ -243,7 +244,17 @@ class KalshiSource(MarketSource):
 
             resolution_window = self._resolution_window(market)
             if resolution_window is None:
-                raise ValueError(f"Invalid Kalshi resolution window for {row['id']}.")
+                if question_id in newly_added_ids:
+                    dfq = dfq.drop(index=index)
+                    action = "Dropped new"
+                else:
+                    dfq.at[index, "freeze_datetime_value"] = "N/A"
+                    action = "Quarantined existing"
+                logger.warning(
+                    f"{action} Kalshi market {question_id} because its resolution window "
+                    "is invalid."
+                )
+                continue
             earliest_resolution_time, _ = resolution_window
 
             # Assign market details to dfq row
@@ -822,15 +833,17 @@ class KalshiSource(MarketSource):
         """Return the credible earliest and latest resolution timestamps.
 
         Kalshi's close time can be a late postponement bound rather than the time the outcome is
-        expected to become known. Required timestamp keys are accessed directly so absent API
+        expected to become known. Once a market has closed, its actual close and occurrence times
+        supersede scheduling estimates that Kalshi may leave unchanged after an early settlement.
+        Timestamp keys needed for the market's lifecycle state are accessed directly so absent API
         fields still fail loudly; present but unusable or inconsistent timestamps make the market
         ineligible.
         """
-        timestamps = {
-            "close": market["close_time"],
-            "expected": market["expected_expiration_time"],
-            "latest": market["latest_expiration_time"],
-        }
+        post_close = market.get("status") in _POST_CLOSE_STATUSES
+        timestamps = {"close": market["close_time"]}
+        if not post_close:
+            timestamps["expected"] = market["expected_expiration_time"]
+            timestamps["latest"] = market["latest_expiration_time"]
         occurrence_datetime = market.get("occurrence_datetime")
         if not all(
             isinstance(timestamp, str) and timestamp.strip() for timestamp in timestamps.values()
@@ -855,9 +868,16 @@ class KalshiSource(MarketSource):
         ):
             return None
 
-        earliest_fields = ["close", "expected"]
+        earliest_fields = ["close"]
         if "occurrence" in parsed_datetimes:
             earliest_fields.append("occurrence")
+
+        if post_close:
+            earliest_field = min(earliest_fields, key=parsed_datetimes.__getitem__)
+            latest_field = max(earliest_fields, key=parsed_datetimes.__getitem__)
+            return timestamps[earliest_field], timestamps[latest_field]
+
+        earliest_fields.append("expected")
         earliest_field = min(earliest_fields, key=parsed_datetimes.__getitem__)
         latest_field = max(("close", "latest"), key=parsed_datetimes.__getitem__)
         latest_resolution_datetime = parsed_datetimes[latest_field]

--- a/src/tests/test_kalshi.py
+++ b/src/tests/test_kalshi.py
@@ -1305,8 +1305,8 @@ class TestUpdate:
             status="closed",
             close_time="2026-07-24T05:00:00Z",
             occurrence_datetime="2026-08-25T05:00:00Z",
-            expected_expiration_time="2026-08-25T05:00:00Z",
-            latest_expiration_time="2026-08-26T05:00:00Z",
+            expected_expiration_time="2027-01-01T00:00:00Z",
+            latest_expiration_time="2026-07-24T05:00:00Z",
         )
         mock_build.return_value = make_resolution_df(
             [{"id": "KXCLOSED-001", "date": "2026-07-23", "value": 0.5}]
@@ -1419,25 +1419,72 @@ class TestUpdate:
 
     @patch.object(KalshiSource, "_build_resolution_df")
     @patch.object(KalshiSource, "_get_market")
-    def test_market_becomes_resolved(self, mock_market, mock_build, kalshi_source):
-        """Market with a terminal status marks the dfq row as resolved."""
+    def test_early_settlement_becomes_resolved(self, mock_market, mock_build, kalshi_source):
+        """A finalized early close ignores the stale scheduled expiration."""
         mock_market.return_value = make_kalshi_api_market(
-            ticker="KXTEST-001",
+            ticker="KXGOVOKNOMR-26-MMAZ",
             status="finalized",
             result="yes",
-            settlement_ts="2026-01-13T05:00:00Z",
+            occurrence_datetime="2026-08-26T02:51:02.814Z",
+            close_time="2026-08-26T03:03:07Z",
+            latest_expiration_time="2026-08-26T03:03:07Z",
+            expected_expiration_time="2027-01-01T15:00:21Z",
+            settlement_ts="2026-08-26T03:08:17.058528Z",
         )
         mock_build.return_value = make_resolution_df(
-            [{"id": "KXTEST-001", "date": "2024-06-01", "value": 1.0}]
+            [{"id": "KXGOVOKNOMR-26-MMAZ", "date": "2026-08-26", "value": 1.0}]
         )
-        dfq = make_question_df([{"id": "KXTEST-001", "resolved": False}])
-        dff = make_kalshi_fetch_df([{"id": "KXTEST-001"}])
+        dfq = make_question_df([{"id": "KXGOVOKNOMR-26-MMAZ", "resolved": False}])
+        dff = make_kalshi_fetch_df([{"id": "KXGOVOKNOMR-26-MMAZ"}])
 
         result = kalshi_source.update(dfq, dff)
 
-        row = result.dfq[result.dfq["id"] == "KXTEST-001"].iloc[0]
+        row = result.dfq[result.dfq["id"] == "KXGOVOKNOMR-26-MMAZ"].iloc[0]
         assert bool(row["resolved"]) is True
-        assert "2026-01-13" in str(row["market_info_resolution_datetime"])
+        assert row["market_info_close_datetime"] == "2026-08-26T02:51:02+00:00"
+        assert row["market_info_resolution_datetime"] == "2026-08-26T03:08:17+00:00"
+
+    @patch.object(KalshiSource, "_build_resolution_df")
+    @patch.object(KalshiSource, "_get_market")
+    def test_invalid_windows_are_isolated_without_aborting(
+        self, mock_market, mock_build, kalshi_source
+    ):
+        """Unusable markets cannot prevent valid stored questions from updating."""
+        markets = {
+            "invalid": make_kalshi_api_market(ticker="invalid", occurrence_datetime="not-a-date"),
+            "valid": make_kalshi_api_market(ticker="valid", title="Updated valid question"),
+            "new-invalid": make_kalshi_api_market(
+                ticker="new-invalid", occurrence_datetime="not-a-date"
+            ),
+        }
+        mock_market.side_effect = lambda ticker: markets[ticker]
+        mock_build.side_effect = lambda market, **kwargs: make_resolution_df(
+            [{"id": market["ticker"], "date": "2026-08-01", "value": 0.6}]
+        )
+        dfq = make_question_df(
+            [
+                {
+                    "id": "invalid",
+                    "question": "Persisted invalid question",
+                    "freeze_datetime_value": "0.4",
+                },
+                {
+                    "id": "valid",
+                    "question": "Persisted valid question",
+                    "freeze_datetime_value": "0.5",
+                },
+            ]
+        )
+
+        result = kalshi_source.update(dfq, make_kalshi_fetch_df([{"id": "new-invalid"}]))
+
+        questions = result.dfq.set_index("id")
+        assert questions.at["invalid", "question"] == "Persisted invalid question"
+        assert questions.at["invalid", "freeze_datetime_value"] == "N/A"
+        assert questions.at["valid", "question"] == "Updated valid question"
+        assert float(questions.at["valid", "freeze_datetime_value"]) == 0.6
+        assert "new-invalid" not in questions.index
+        assert set(result.resolution_files) == {"valid"}
 
     @pytest.mark.parametrize(("outcome", "expected"), [("yes", 1.0), ("no", 0.0)])
     def test_finalization_replaces_stale_settlement_probability(


### PR DESCRIPTION
## Summary

- Handle early-settled Kalshi markets whose scheduled expiration timestamps remain stale.
- Use actual close and occurrence timestamps for markets that have already closed.
- Isolate markets with invalid resolution windows instead of aborting the entire update.

## Testing

- Kalshi and schema tests pass: 121 passed.
- Cloud Run execution `func-data-kalshi-update-questions` completed successfully.
- Verified that the affected Oklahoma contracts resolved correctly to `0.0` and `1.0`.