### PR TITLE
feat: send Slack alerts for invalid Kalshi resolution windows

### DIFF
--- a/src/orchestration/func_kalshi_update/main.py
+++ b/src/orchestration/func_kalshi_update/main.py
@@ -1,6 +1,7 @@
 """Kalshi update entry point."""
 
 import logging
+from importlib import import_module
 from typing import Any
 
 from helpers import data_utils, decorator
@@ -11,6 +12,22 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 SOURCE = "kalshi"
+
+
+def _alert_invalid_resolution_windows(actions: list[str]) -> None:
+    """Alert on isolated invalid markets without risking the update job."""
+    if not actions:
+        return
+    message = (
+        f":warning: Kalshi update found {len(actions)} market(s) with invalid resolution windows: "
+        f"{', '.join(actions)}.\n"
+        "Review any quarantined existing question and resolution file manually."
+    )
+    try:
+        slack = import_module("helpers.slack")
+        slack.send_message(message=message)
+    except Exception:
+        logger.exception("Failed to send the Kalshi invalid-resolution-window Slack alert.")
 
 
 @decorator.log_runtime
@@ -44,6 +61,7 @@ def driver(_: Any) -> None:
     data_utils.upload_questions(result.dfq, SOURCE)
     if result.resolution_files:
         _source_io.upload_resolution_files(SOURCE, result.resolution_files)
+    _alert_invalid_resolution_windows(source.invalid_resolution_window_actions)
 
     logger.info("Done.")
 

--- a/src/orchestration/func_kalshi_update/requirements.txt
+++ b/src/orchestration/func_kalshi_update/requirements.txt
@@ -7,3 +7,4 @@ requests
 certifi
 backoff
 numpy
+slack_sdk

--- a/src/sources/kalshi.py
+++ b/src/sources/kalshi.py
@@ -185,6 +185,7 @@ class KalshiSource(MarketSource):
         """
         existing_resolution_files = existing_resolution_files or {}
         existing_resolution_ids = existing_resolution_ids or set()
+        self.invalid_resolution_window_actions: list[str] = []
         persisted_dfq = dfq.copy(deep=True)
         persisted_ids = set(persisted_dfq["id"].astype(str))
         nullified_ids = self.get_nullified_ids()
@@ -250,6 +251,7 @@ class KalshiSource(MarketSource):
                 else:
                     dfq.at[index, "freeze_datetime_value"] = "N/A"
                     action = "Quarantined existing"
+                self.invalid_resolution_window_actions.append(f"{action}: {question_id}")
                 logger.warning(
                     f"{action} Kalshi market {question_id} because its resolution window "
                     "is invalid."

--- a/src/tests/test_kalshi.py
+++ b/src/tests/test_kalshi.py
@@ -1485,6 +1485,10 @@ class TestUpdate:
         assert float(questions.at["valid", "freeze_datetime_value"]) == 0.6
         assert "new-invalid" not in questions.index
         assert set(result.resolution_files) == {"valid"}
+        assert kalshi_source.invalid_resolution_window_actions == [
+            "Quarantined existing: invalid",
+            "Dropped new: new-invalid",
+        ]
 
     @pytest.mark.parametrize(("outcome", "expected"), [("yes", 1.0), ("no", 0.0)])
     def test_finalization_replaces_stale_settlement_probability(
@@ -1772,8 +1776,10 @@ def test_update_driver_downloads_only_unresolved_resolution_histories():
             return_value={"active", "finalized"},
         ),
         patch.object(update_main, "KalshiSource") as mock_source_class,
+        patch.object(update_main, "_alert_invalid_resolution_windows") as mock_alert,
     ):
         mock_source_class.return_value.get_nullified_ids.return_value = {"nullified"}
+        mock_source_class.return_value.invalid_resolution_window_actions = []
         mock_source_class.return_value.update.return_value = Mock(
             dfq=dfq,
             resolution_files={},
@@ -1783,6 +1789,33 @@ def test_update_driver_downloads_only_unresolved_resolution_histories():
 
     downloaded_paths = [call.kwargs["filename"] for call in mock_download.call_args_list]
     assert downloaded_paths == ["kalshi/active.jsonl"]
+    mock_alert.assert_called_once_with([])
+
+
+def test_invalid_resolution_window_alert_is_aggregated():
+    """The update entry point sends one concise alert for all isolated markets."""
+    from orchestration.func_kalshi_update import main as update_main
+
+    slack = Mock()
+    actions = ["Quarantined existing: invalid", "Dropped new: new-invalid"]
+
+    with patch.object(update_main, "import_module", return_value=slack):
+        update_main._alert_invalid_resolution_windows(actions)
+
+    message = slack.send_message.call_args.kwargs["message"]
+    assert message.splitlines() == [
+        ":warning: Kalshi update found 2 market(s) with invalid resolution windows: "
+        "Quarantined existing: invalid, Dropped new: new-invalid.",
+        "Review any quarantined existing question and resolution file manually.",
+    ]
+
+
+def test_invalid_resolution_window_alert_failure_does_not_abort():
+    """A Slack or Secret Manager failure cannot turn isolation into a failed update."""
+    from orchestration.func_kalshi_update import main as update_main
+
+    with patch.object(update_main, "import_module", side_effect=RuntimeError("Slack unavailable")):
+        update_main._alert_invalid_resolution_windows(["Quarantined existing: invalid"])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds one aggregated Slack alert when Kalshi markets are dropped or quarantined due to invalid resolution windows. Alert failures do not block the update job.

Tests: 104 Kalshi tests passed.