### PR TITLE
feat: expand DBnomics questions with curated ECB series

### DIFF
--- a/src/orchestration/func_dbnomics_fetch/Makefile
+++ b/src/orchestration/func_dbnomics_fetch/Makefile
@@ -18,8 +18,8 @@ deploy : main.py .gcloudignore requirements.txt Dockerfile
 		--region $(CLOUD_DEPLOY_REGION) \
 		--tasks 1 \
 		--parallelism 1 \
-		--task-timeout 540s \
-		--memory 512Mi \
+		--task-timeout 2h \
+		--memory 1Gi \
 		--max-retries 0 \
 		--service-account $(QUESTION_BANK_BUCKET_SERVICE_ACCOUNT) \
 		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS) \

--- a/src/orchestration/func_dbnomics_update/Makefile
+++ b/src/orchestration/func_dbnomics_update/Makefile
@@ -18,8 +18,8 @@ deploy : main.py .gcloudignore requirements.txt Dockerfile
 		--region $(CLOUD_DEPLOY_REGION) \
 		--tasks 1 \
 		--parallelism 1 \
-		--task-timeout 540s \
-		--memory 1Gi \
+		--task-timeout 1000s \
+		--memory 4Gi \
 		--max-retries 0 \
 		--service-account $(QUESTION_BANK_BUCKET_SERVICE_ACCOUNT) \
 		--set-env-vars $(DEFAULT_CLOUD_FUNCTION_ENV_VARS) \

--- a/src/orchestration/func_dbnomics_update/main.py
+++ b/src/orchestration/func_dbnomics_update/main.py
@@ -3,16 +3,35 @@
 from __future__ import annotations
 
 import logging
+from importlib import import_module
 from typing import Any
 
 from helpers import data_utils, decorator
 from orchestration import _source_io
-from sources.dbnomics import DbnomicsSource
+from sources.dbnomics import MAX_OBSERVATION_AGE_DAYS, DbnomicsSource
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 SOURCE = "dbnomics"
+
+
+def _alert_stale_series(warnings: list[str]) -> None:
+    """Notify operators about excluded series without risking the saved update."""
+    if not warnings:
+        return
+    message = (
+        f":warning: DBnomics: {len(warnings)} series excluded from new question sets. "
+        f"No fetched data or no non-missing observation within {MAX_OBSERVATION_AGE_DAYS} days.\n"
+        + "\n".join(warnings[:20])
+    )
+    if len(warnings) > 20:
+        message += f"\n...and {len(warnings) - 20} more; see the update job logs for all IDs."
+    try:
+        slack = import_module("helpers.slack")
+        slack.send_message(message=message)
+    except Exception:
+        logger.exception("Failed to send the DBnomics freshness Slack alert.")
 
 
 @decorator.log_runtime
@@ -30,6 +49,7 @@ def driver(_: Any) -> None:
     data_utils.upload_questions(result.dfq, SOURCE)
     if result.resolution_files:
         _source_io.upload_resolution_files(SOURCE, result.resolution_files)
+    _alert_stale_series(source.freshness_warnings)
     logger.info("Done.")
 
 

--- a/src/orchestration/func_dbnomics_update/requirements.txt
+++ b/src/orchestration/func_dbnomics_update/requirements.txt
@@ -1,4 +1,5 @@
 google-cloud-storage
+slack_sdk
 pandas>=2.2.2,<3.0
 pandera
 requests

--- a/src/sources/dbnomics.py
+++ b/src/sources/dbnomics.py
@@ -50,7 +50,10 @@ _QUESTION_TEMPLATES = {
 }
 
 _VALUE_EXPLANATIONS = {
-    "meteofrance": "The daily average temperature at the French weather station at {station}.",
+    "meteofrance": (
+        "The latest value published as of the question-set freeze date for the daily average "
+        "temperature at the French weather station at {station}."
+    ),
     "ecb": (
         "The latest value published as of the question-set freeze date for "
         "“{question_subject}” in the European Central Bank’s “{dataset_name}” dataset."

--- a/src/sources/dbnomics.py
+++ b/src/sources/dbnomics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date
 from typing import Any, ClassVar
 
 import backoff
@@ -16,10 +17,15 @@ from _schemas import DbnomicsFetchFrame, QuestionFrame, ResolutionFrame
 from helpers import constants, data_utils, dates
 
 from ._dataset import DatasetSource
+from .dbnomics_questions import ECB_QUESTIONS, METEOFRANCE_STATIONS
 
 logger = logging.getLogger(__name__)
 
 _BASE_URL = "https://api.db.nomics.world/v22/series/"
+_PROVIDER_NAMES = {
+    "ECB": "European Central Bank",
+    "meteofrance": "Météo-France",
+}
 
 # Some dataseries with regular updates have large numbers of NA values during periods in which
 # data is not being reported. _OBSERVATIONS_WITHOUT_DATA detects these quiet periods and excludes
@@ -27,97 +33,83 @@ _BASE_URL = "https://api.db.nomics.world/v22/series/"
 # resolve them and the freeze values become increasingly irrelevant).
 _OBSERVATIONS_WITHOUT_DATA = 10
 
-_METEOFRANCE_STATIONS = [
-    {"id": "07005", "station": "Abbeville"},
-    {"id": "07015", "station": "Lille Airport"},
-    {"id": "07020", "station": "Pointe De La Hague"},
-    {"id": "07027", "station": "Caen – Carpiquet Airport"},
-    {"id": "07037", "station": "Rouen Airport"},
-    {"id": "07072", "station": "Reims – Prunay Aerodrome"},
-    {"id": "07110", "station": "Brest Bretagne Airport"},
-    {"id": "07117", "station": "Ploumanac'h"},
-    {"id": "07130", "station": "Rennes–Saint-Jacques Airport"},
-    {"id": "07139", "station": "Alençon"},
-    {"id": "07149", "station": "Orly"},
-    {"id": "07168", "station": "Troyes-Barberey Airport"},
-    {"id": "07181", "station": "Nancy – Ochey Air Base"},
-    {"id": "07190", "station": "Strasbourg Airport"},
-    {"id": "07222", "station": "Nantes Atlantique Airport"},
-    {"id": "07240", "station": "Tours"},
-    {"id": "07255", "station": "Bourges"},
-    {"id": "07280", "station": "Dijon-Bourgogne Airport"},
-    {"id": "07299", "station": "EuroAirport Basel Mulhouse Freiburg"},
-    {"id": "07335", "station": "Poitiers–Biard Airport"},
-    {"id": "07434", "station": "Limoges – Bellegarde Airport"},
-    {"id": "07460", "station": "Clermont-Ferrand Auvergne Airport"},
-    {"id": "07471", "station": "Le Puy – Loudes Airport"},
-    {"id": "07481", "station": "Lyon–Saint Exupéry Airport"},
-    {"id": "07510", "station": "Bordeaux–Mérignac Airport"},
-    {"id": "07535", "station": "Gourdon"},
-    {"id": "07558", "station": "Millau"},
-    {"id": "07577", "station": "Montélimar"},
-    {"id": "07591", "station": "Embrun"},
-    {"id": "07607", "station": "Mont-de-Marsan"},
-    {"id": "07621", "station": "Tarbes–Lourdes–Pyrénées Airport"},
-    {"id": "07627", "station": "Saint-Girons"},
-    {"id": "07630", "station": "Toulouse–Blagnac Airport"},
-    {"id": "07650", "station": "Marignane"},
-    {"id": "07690", "station": "Nice"},
-    {"id": "07747", "station": "Perpignan"},
-    {"id": "07761", "station": "Ajaccio"},
-    {"id": "61968", "station": "Glorioso Islands"},
-    {"id": "61970", "station": "Juan de Nova Island"},
-    {"id": "61972", "station": "Europa Island"},
-    {"id": "61976", "station": "Tromelin Island"},
-    {"id": "61980", "station": "Roland Garros Airport"},
-    {"id": "61996", "station": "Amsterdam Island"},
-    {"id": "61997", "station": "Île de la Possession"},
-    {"id": "61998", "station": "Grande Terre"},
-    {"id": "67005", "station": "Pamandzi"},
-    {"id": "71805", "station": "Saint-Pierre"},
-    {"id": "78890", "station": "La Désirade"},
-    {"id": "78894", "station": "Saint Barthélemy"},
-    {"id": "78897", "station": "Pointe-à-Pitre International Airport"},
-    {"id": "78925", "station": "Martinique Aimé Césaire International Airport"},
-    {"id": "81401", "station": "Saint-Laurent"},
-    {"id": "81405", "station": "Cayenne – Félix Éboué Airport"},
-]
+# Allow a weekly observation plus three days for publication/ingestion delays.
+MAX_OBSERVATION_AGE_DAYS = 10
 
 _QUESTION_TEMPLATES = {
     "meteofrance": (
         "What is the probability that the daily average temperature at the French weather station "
         "at {station} will be higher on {resolution_date} than on {forecast_due_date}?"
-    )
+    ),
+    "ecb": (
+        "What is the probability that the value of the latest observation dated on or before "
+        "{resolution_date} for the European Central Bank time series “{question_subject}” "
+        "will exceed the value of its latest observation dated on or before "
+        "{forecast_due_date}?"
+    ),
 }
 
 _VALUE_EXPLANATIONS = {
-    "meteofrance": "The daily average temperature at the French weather station at {station}."
+    "meteofrance": "The daily average temperature at the French weather station at {station}.",
+    "ecb": (
+        "The latest value published as of the question-set freeze date for "
+        "“{question_subject}” in the European Central Bank’s “{dataset_name}” dataset."
+    ),
 }
 
 
-def _create_meteofrance_constants(stations: list[dict]) -> list[dict]:
-    """Convert station data into the series config consumed by fetch and update.
+def _create_meteofrance_questions(stations: list[dict]) -> list[dict]:
+    """Convert station data into the question config consumed by fetch and update.
 
     Args:
         stations (list[dict]): MeteoFrance station entries with ``id`` and ``station``.
     """
-    constants_list = []
+    questions = []
     for item in stations:
         station_id = item["id"]
         station = item["station"]
         question_text = _QUESTION_TEMPLATES["meteofrance"].replace("{station}", station)
         explanation = _VALUE_EXPLANATIONS["meteofrance"].format(station=station)
-        constants_list.append(
+        questions.append(
             {
                 "id": f"meteofrance/TEMPERATURE/celsius.{station_id}.D",
                 "question_text": question_text,
                 "freeze_datetime_value_explanation": explanation,
+                "fill_missing_dates": False,
             }
         )
-    return constants_list
+    return questions
 
 
-_CONSTANTS = _create_meteofrance_constants(_METEOFRANCE_STATIONS)
+def _create_ecb_questions(series: list[dict[str, str]]) -> list[dict]:
+    """Convert curated ECB series into the question config consumed by fetch and update.
+
+    Args:
+        series (list[dict[str, str]]): ECB series IDs and question metadata.
+    """
+    questions = []
+    for item in series:
+        question_text = _QUESTION_TEMPLATES["ecb"].replace(
+            "{question_subject}", item["question_subject"]
+        )
+        explanation = _VALUE_EXPLANATIONS["ecb"].format(
+            question_subject=item["question_subject"],
+            dataset_name=item["dataset_name"],
+        )
+        questions.append(
+            {
+                "id": item["id"],
+                "question_text": question_text,
+                "freeze_datetime_value_explanation": explanation,
+                "fill_missing_dates": True,
+            }
+        )
+    return questions
+
+
+DBNOMICS_QUESTIONS = _create_meteofrance_questions(METEOFRANCE_STATIONS) + _create_ecb_questions(
+    ECB_QUESTIONS
+)
 
 
 class DbnomicsSource(DatasetSource):
@@ -125,23 +117,33 @@ class DbnomicsSource(DatasetSource):
 
     name: ClassVar[str] = "dbnomics"
 
+    def __init__(self) -> None:
+        """Initialize the source and its per-update freshness warnings."""
+        super().__init__()
+        self.freshness_warnings: list[str] = []
+
     # ------------------------------------------------------------------
     # Public: fetch
     # ------------------------------------------------------------------
 
     @pa.check_types
     def fetch(self, **kwargs: Any) -> DataFrame[DbnomicsFetchFrame]:
-        """Fetch DBnomics series data from the public API."""
+        """Fetch DBnomics series data from the API."""
         # Compute 'today' once and thread it to every series call so a run straddling midnight
         # uses one consistent upper bound across all of its requests.
         today = dates.get_date_today()
         logger.info("Downloading DBnomics data.")
 
-        df = None
-        for row in _CONSTANTS:
+        frames = []
+        for row in DBNOMICS_QUESTIONS:
             new_rows = self._call_endpoint(id=row["id"], today=today)
-            df = new_rows if df is None else pd.concat([df, new_rows])
+            if new_rows is not None:
+                frames.append(new_rows)
 
+        if not frames:
+            raise RuntimeError("No DBnomics series returned usable observations.")
+
+        df = pd.concat(frames, ignore_index=True)
         df["period"] = df["period"].astype(str)
         return df
 
@@ -169,14 +171,25 @@ class DbnomicsSource(DatasetSource):
         dff[["id", "period", "value"]] = dff[["id", "period", "value"]].astype(str)
 
         yesterday = dates.get_date_yesterday()
+        today = dates.get_date_today()
+        self.freshness_warnings = []
         resolution_files: dict[str, pd.DataFrame] = {}
 
         new_series = None
-        for row in _CONSTANTS:
+        for row in DBNOMICS_QUESTIONS:
             id = row["id"].replace("/", "_")
             df_series = dff[dff["id"] == id]
+            if df_series.empty:
+                warning = f"{row['id']}: no fetched observations"
+                logger.warning(warning)
+                self.freshness_warnings.append(warning)
+                dfq.loc[dfq["id"] == id, "resolved"] = True
+                continue
 
-            resolution_files[id] = self._build_resolution_df(df_series)
+            df_series = df_series.sort_values("period")
+
+            fill_through = yesterday if row["fill_missing_dates"] else None
+            resolution_files[id] = self._build_resolution_df(df_series, fill_through=fill_through)
 
             provider_name = df_series["provider_name"].iloc[0]
             dataset_name = df_series["dataset_name"].iloc[0]
@@ -189,17 +202,19 @@ class DbnomicsSource(DatasetSource):
             )
             freeze_datetime_value_explanation = row["freeze_datetime_value_explanation"]
             series_values = df_series["value"]
-            series_dates = pd.to_datetime(df_series["period"])
 
-            last_fetch_date = series_dates.iloc[-1]
-            last_fetch_value = series_values.iloc[-1]
-            freeze_datetime_value = (
-                float(last_fetch_value)
-                if last_fetch_date.date() > yesterday and last_fetch_value != "NA"
-                else "N/A"
-            )
+            valid_periods = df_series.loc[series_values != "NA", "period"]
+            latest = date.fromisoformat(valid_periods.iloc[-1]) if not valid_periods.empty else None
+            if latest is None or (today - latest).days > MAX_OBSERVATION_AGE_DAYS:
+                warning = f"{row['id']}: latest non-missing observation {latest or 'unavailable'}"
+                logger.warning(warning)
+                self.freshness_warnings.append(warning)
+                # Curation excludes resolved rows; keep history for already-issued questions.
+                dfq.loc[dfq["id"] == id, "resolved"] = True
+                continue
 
             if (series_values.tail(_OBSERVATIONS_WITHOUT_DATA) != "NA").any():
+                freeze_datetime_value = float(series_values[series_values != "NA"].iloc[-1])
                 new_row = {
                     "id": id,
                     "question": question,
@@ -222,16 +237,17 @@ class DbnomicsSource(DatasetSource):
                         else pd.concat([new_series, new_row], ignore_index=True)
                     )
                 else:
-                    dfq.loc[dfq["id"] == id, "freeze_datetime_value"] = float(
-                        series_values[series_values != "NA"].iloc[-1]
-                    )
+                    dfq.loc[dfq["id"] == id, "freeze_datetime_value"] = freeze_datetime_value
+                    dfq.loc[dfq["id"] == id, "resolved"] = False
                     dfq.loc[dfq["id"] == id, "url"] = url
                     dfq.loc[dfq["id"] == id, "background"] = background
+            else:
+                dfq.loc[dfq["id"] == id, "resolved"] = True
 
         if new_series is not None:
             dfq = pd.concat([dfq, new_series])
 
-        logger.info(f"Found {len(dfq):,} questions of {len(_CONSTANTS):,} possible.")
+        logger.info(f"Found {len(dfq):,} questions of {len(DBNOMICS_QUESTIONS):,} possible.")
 
         return UpdateResult(dfq=dfq, resolution_files=resolution_files)
 
@@ -254,8 +270,10 @@ class DbnomicsSource(DatasetSource):
         """
         logger.info(f"Calling DBnomics for series {id}")
         endpoint = _BASE_URL + id
-        params = {"observations": "true"}
-        response = requests.get(url=endpoint, params=params)
+        # metadata=0 omits large provider and dataset metadata objects that would otherwise bloat
+        # every response; the series document still contains the compact labels used below.
+        params = {"observations": 1, "metadata": 0}
+        response = requests.get(url=endpoint, params=params, timeout=(10, 60))
         if not response.ok:
             logger.error("Request to DBnomics API endpoint failed.")
             response.raise_for_status()
@@ -267,7 +285,7 @@ class DbnomicsSource(DatasetSource):
                 "id": id_safe,
                 "period": docs.get("period"),
                 "value": docs.get("value"),
-                "provider_name": data.get("provider", {}).get("name"),
+                "provider_name": _PROVIDER_NAMES[docs.get("provider_code")],
                 "dataset_name": docs.get("dataset_name"),
                 "series_name": docs.get("series_name"),
             }
@@ -285,13 +303,27 @@ class DbnomicsSource(DatasetSource):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _build_resolution_df(df: pd.DataFrame) -> DataFrame[ResolutionFrame]:
+    def _build_resolution_df(
+        df: pd.DataFrame, fill_through: date | None = None
+    ) -> DataFrame[ResolutionFrame]:
         """Build a resolution DataFrame ([id, date, value]) for a single series.
 
         Args:
             df (pd.DataFrame): Fetched rows for this series.
+            fill_through (date | None): If set, carry observations forward through this date.
         """
         df = df[["id", "period", "value"]].rename(columns={"period": "date"})
+        if fill_through is not None:
+            df["date"] = pd.to_datetime(df["date"])
+            # Match other dataset sources by treating the provider's missing-value sentinel as
+            # missing before expanding to calendar dates and carrying the latest value forward.
+            df["value"] = df["value"].replace("NA", pd.NA)
+            dates_to_fill = pd.date_range(df["date"].min(), fill_through, freq="D")
+            df = df.set_index("date").reindex(dates_to_fill).ffill()
+            df["value"] = df["value"].fillna("NA")
+            df.index.name = "date"
+            df = df.reset_index()
+            df["date"] = df["date"].dt.strftime("%Y-%m-%d")
         df = df.astype(dtype=constants.RESOLUTION_FILE_COLUMN_DTYPE)
         df["value"] = df["value"].replace("NA", "N/A")
         return df

--- a/src/sources/dbnomics_questions.py
+++ b/src/sources/dbnomics_questions.py
@@ -1,0 +1,2774 @@
+"""DBnomics predefined series catalogues.
+
+Only consumed by ``sources.dbnomics``; kept in a separate file purely for maintainability.
+"""
+
+# flake8: noqa: B950
+
+METEOFRANCE_STATIONS = [
+    {"id": "07005", "station": "Abbeville"},
+    {"id": "07015", "station": "Lille Airport"},
+    {"id": "07020", "station": "Pointe De La Hague"},
+    {"id": "07027", "station": "Caen – Carpiquet Airport"},
+    {"id": "07037", "station": "Rouen Airport"},
+    {"id": "07072", "station": "Reims – Prunay Aerodrome"},
+    {"id": "07110", "station": "Brest Bretagne Airport"},
+    {"id": "07117", "station": "Ploumanac'h"},
+    {"id": "07130", "station": "Rennes–Saint-Jacques Airport"},
+    {"id": "07139", "station": "Alençon"},
+    {"id": "07149", "station": "Orly"},
+    {"id": "07168", "station": "Troyes-Barberey Airport"},
+    {"id": "07181", "station": "Nancy – Ochey Air Base"},
+    {"id": "07190", "station": "Strasbourg Airport"},
+    {"id": "07222", "station": "Nantes Atlantique Airport"},
+    {"id": "07240", "station": "Tours"},
+    {"id": "07255", "station": "Bourges"},
+    {"id": "07280", "station": "Dijon-Bourgogne Airport"},
+    {"id": "07299", "station": "EuroAirport Basel Mulhouse Freiburg"},
+    {"id": "07335", "station": "Poitiers–Biard Airport"},
+    {"id": "07434", "station": "Limoges – Bellegarde Airport"},
+    {"id": "07460", "station": "Clermont-Ferrand Auvergne Airport"},
+    {"id": "07471", "station": "Le Puy – Loudes Airport"},
+    {"id": "07481", "station": "Lyon–Saint Exupéry Airport"},
+    {"id": "07510", "station": "Bordeaux–Mérignac Airport"},
+    {"id": "07535", "station": "Gourdon"},
+    {"id": "07558", "station": "Millau"},
+    {"id": "07577", "station": "Montélimar"},
+    {"id": "07591", "station": "Embrun"},
+    {"id": "07607", "station": "Mont-de-Marsan"},
+    {"id": "07621", "station": "Tarbes–Lourdes–Pyrénées Airport"},
+    {"id": "07627", "station": "Saint-Girons"},
+    {"id": "07630", "station": "Toulouse–Blagnac Airport"},
+    {"id": "07650", "station": "Marignane"},
+    {"id": "07690", "station": "Nice"},
+    {"id": "07747", "station": "Perpignan"},
+    {"id": "07761", "station": "Ajaccio"},
+    {"id": "61968", "station": "Glorioso Islands"},
+    {"id": "61970", "station": "Juan de Nova Island"},
+    {"id": "61972", "station": "Europa Island"},
+    {"id": "61976", "station": "Tromelin Island"},
+    {"id": "61980", "station": "Roland Garros Airport"},
+    {"id": "61996", "station": "Amsterdam Island"},
+    {"id": "61997", "station": "Île de la Possession"},
+    {"id": "61998", "station": "Grande Terre"},
+    {"id": "67005", "station": "Pamandzi"},
+    {"id": "71805", "station": "Saint-Pierre"},
+    {"id": "78890", "station": "La Désirade"},
+    {"id": "78894", "station": "Saint Barthélemy"},
+    {"id": "78897", "station": "Pointe-à-Pitre International Airport"},
+    {"id": "78925", "station": "Martinique Aimé Césaire International Airport"},
+    {"id": "81401", "station": "Saint-Laurent"},
+    {"id": "81405", "station": "Cayenne – Félix Éboué Airport"},
+]
+
+
+ECB_QUESTIONS = [
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_FXN.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from foreign exchange "
+        "market subindex",
+    },
+    {
+        "id": "ECB/CISS/D.IE.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Ireland – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_BMN.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from bond market subindex",
+    },
+    {
+        "id": "ECB/CISS/D.IT.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Italy – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.FI.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Finland – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.FI.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Finland – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_MMN.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from money market subindex",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – New Composite Indicator of Systemic "
+        "Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.GB.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "United Kingdom – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.AT.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Austria – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.DE.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Germany – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.IT.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Italy – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.DE.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Germany – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.GR.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Greece – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.FR.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "France – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SOV_GDPWN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Correlation and real GDP-country weights "
+        "average",
+    },
+    {
+        "id": "ECB/CISS/D.AT.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Austria – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.BE.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Belgium – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_CON.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from cross-subindex "
+        "correlations",
+    },
+    {
+        "id": "ECB/CISS/D.BE.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Belgium – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.PT.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Portugal – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_EMN.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from equity market "
+        "subindex",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SOV_EWN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Correlation and equal-country weights",
+    },
+    {
+        "id": "ECB/CISS/D.NL.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Netherlands – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.US.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "United States – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.PT.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Portugal – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.ES.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Spain – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.FR.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "France – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.IE.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Ireland – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/CISS/D.U2.Z0Z.4F.EC.SS_FIN.CON",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Euro area (changing composition) – Contribution from financial intermediary "
+        "subindex",
+    },
+    {
+        "id": "ECB/CISS/D.NL.Z0Z.4F.EC.SS_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Netherlands – New Composite Indicator of Systemic Stress (CISS)",
+    },
+    {
+        "id": "ECB/CISS/D.ES.Z0Z.4F.EC.SOV_CIN.IDX",
+        "dataset_name": "Composite Indicator of Systemic Stress",
+        "question_subject": "Spain – Composite Indicator of Sovereign Stress",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.R25",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Rate at 25th percentile of volume",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF08.CI",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Compounded Euro Short-Term Rate Index – Index of compounded interest",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.VL",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Share of volume of the 5 largest active banks",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF57.CR",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "12-months compounded euro short-term average rate",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.NT",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Number of transactions",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF24.CR",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "1-month compounded euro short-term average rate",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF16.CR",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "1-week compounded euro short-term average rate",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.WT",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Volume-weighted trimmed mean rate",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF40.CR",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "6-months compounded euro short-term average rate",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.NB",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Number of active banks",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.R75",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Rate at 75th percentile of volume",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2X2A25.TT",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "Euro short-term rate – Total volume",
+    },
+    {
+        "id": "ECB/EST/B.EU000A2QQF32.CR",
+        "dataset_name": "Euro Short-Term Rate",
+        "question_subject": "3-months compounded euro short-term average rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Netherlands "
+        "guilder – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.DKK.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Danish krone per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H01.PTE.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Portuguese escudo – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.BRL.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Brazilian real – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Lithuanian litas – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Latvian lats – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Croatian kuna – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.HKD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Hong Kong dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Belgian franc – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.MXN.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Mexican peso per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.ISK.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Iceland krona per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – French franc – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.NZD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "New Zealand dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H01.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Croatian kuna – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Lithuanian "
+        "litas – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Netherlands guilder – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Luxembourg franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.DKK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Danish krone – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H01.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Slovenian tolar – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Croatian kuna – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.MXN.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Mexican peso – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.FIM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Finnish markka – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Italian lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Luxembourg "
+        "franc – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Maltese lira – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Luxembourg franc – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Latvian lats – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Bulgarian lev – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Luxembourg franc "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.DZD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Algerian dinar – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.MYR.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Malaysian ringgit per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.SGD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Singapore dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Latvian lats – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Irish pound – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.TRY.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Turkish lira per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.EUR.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Euro – Nominal "
+        "effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.SGD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Singapore dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Luxembourg franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.FIM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Finnish markka "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.CAD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Canadian "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Irish pound – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ILS.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Israeli shekel – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Croatian kuna "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Slovak koruna – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.EEK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Estonian kroon – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Maltese lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Latvian lats – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.FIM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Finnish markka – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Slovenian tolar "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.USD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "US dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Italian lira – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Spanish peseta – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.MAD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Moroccan dirham – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Irish pound – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.RON.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Romanian leu per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.USD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – US dollar – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.EEK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Estonian kroon – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Bulgarian lev – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.EEK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Estonian kroon – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Irish pound – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.SEK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Swedish krona "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Austrian "
+        "schilling – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – French franc – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Lithuanian litas – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.PHP.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Philippine peso – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Maltese lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Maltese lira – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.PLN.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Polish zloty – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.KRW.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Korean won "
+        "(Republic) – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.GRD.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Greek drachma – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Irish pound – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.JPY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Japanese yen – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.PTE.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Portuguese "
+        "escudo – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.USD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – US dollar – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Lithuanian litas "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.NZD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – New Zealand "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Lithuanian litas "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Belgian franc – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.CZK.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Czech koruna per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – French franc – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Belgian franc – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.HKD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Hong Kong dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Croatian kuna – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.KRW.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Korean won "
+        "(Republic) – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.DEM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – German mark – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.TRY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Turkish lira – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.NOK.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Norwegian krone per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.DEM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – German mark – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Latvian lats – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.CHF.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Swiss franc – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.PTE.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Portuguese "
+        "escudo – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.KRW.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Korean won "
+        "(Republic) – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.AUD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Australian "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H01.DEM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – German mark – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.GRD.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Greek drachma – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.CZK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Czech koruna – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – French franc – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.INR.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Indian rupee per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.DKK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Danish krone – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.DKK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Danish krone – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.GBP.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "UK pound sterling per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Italian lira – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.SGD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Singapore "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Austrian "
+        "schilling – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ISK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Iceland krona – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – French franc – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Slovak koruna "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Belgian franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Italian lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.PHP.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Philippine peso per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Slovak koruna – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Belgian franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ZAR.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – South African "
+        "rand – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.AUD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Australian dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.CAD.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Canadian dollar per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Slovenian "
+        "tolar – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.CHF.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Swiss franc – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.FIM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Finnish markka – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.PEN.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Peru nuevo sol – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Spanish peseta – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.LTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Lithuanian litas – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.CNY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Chinese yuan "
+        "renminbi – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Bulgarian lev – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.GRD.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Greek drachma – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.LUF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Luxembourg franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Spanish peseta – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.SEK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Swedish krona – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Bulgarian lev – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.HUF.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Hungarian "
+        "forint – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H00.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Netherlands guilder – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.TWD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – New Taiwan dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.CAD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Canadian dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.SEK.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Swedish krona per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.JPY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Japanese yen – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.IDR.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Indonesian rupiah per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.CNY.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Chinese yuan renminbi per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Netherlands "
+        "guilder – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Maltese lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Austrian schilling – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Italian lira – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.UAH.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Ukraine hryvnia – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.IEP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Irish pound – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.THB.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Thai baht – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.PTE.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Portuguese escudo "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.PTE.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Portuguese escudo – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Bulgarian lev – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Netherlands "
+        "guilder – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.KRW.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Korean won (Republic) per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.JPY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Japanese yen – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.BGN.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Bulgarian lev "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.MTL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Maltese lira – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.USD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – US dollar – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.NOK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Norwegian krone – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.HKD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Hong Kong dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H02.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Austrian schilling – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Netherlands guilder – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.ARS.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Argentine peso – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Slovak koruna – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Belgian franc – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.CNY.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Chinese yuan "
+        "renminbi – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.DEM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – German mark – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.CYP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Cyprus pound – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Slovenian tolar – Nominal "
+        "harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.BEF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Belgian franc "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H00.CYP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries (fixed composition) – Cyprus pound – Nominal harmonised "
+        "competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.EEK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Estonian kroon – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.CHF.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Swiss franc per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Croatian kuna – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Spanish peseta "
+        "– Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Slovenian tolar – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.SIT.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Slovenian tolar – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Spanish peseta – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.ILS.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Israeli shekel per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.CZK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Czech koruna – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H01.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Austrian schilling – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.AED.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – United Arab "
+        "Emirates dirham – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.NOK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Norwegian krone "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.HRK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Croatian kuna – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E01.ATS.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Austrian "
+        "schilling – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.FRF.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – French franc – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.INR.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Indian rupee – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.COP.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Colombian peso – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E03.AUD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Australian dollar "
+        "– Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.LVL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Latvian lats – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H03.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Slovak koruna – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.CLP.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Chilean peso – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.AUD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Australian "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.CYP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Cyprus pound – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.HKD.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Hong Kong "
+        "dollar – Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.FIM.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Finnish markka – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.SEK.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Swedish krona – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E01.ESP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Narrow EER group of trading partners (fixed composition) – Spanish peseta – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H01.CYP.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and narrow EER group of trading partners (fixed "
+        "composition) – Cyprus pound – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.PLN.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Polish zloty – "
+        "Nominal effective exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.H03.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and broad EER group of trading partners (fixed "
+        "composition) – Italian lira – Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E03.SKK.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Broad EER group of trading partners (fixed composition) – Slovak koruna – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.H02.NLG.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Euro area countries and extended EER group of trading partners (fixed "
+        "composition) – Netherlands guilder – Nominal harmonised competitiveness "
+        "indicator",
+    },
+    {
+        "id": "ECB/EXR/D.HUF.EUR.SP00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Hungarian forint per euro spot exchange rate",
+    },
+    {
+        "id": "ECB/EXR/D.E02.ITL.NN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Italian lira – "
+        "Nominal harmonised competitiveness indicator",
+    },
+    {
+        "id": "ECB/EXR/D.E02.EUR.EN00.A",
+        "dataset_name": "Exchange Rates",
+        "question_subject": "Extended EER group of trading partners (fixed composition) – Euro – Nominal "
+        "effective exchange rate",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.DFR.CHG",
+        "dataset_name": "Financial market data",
+        "question_subject": "Deposit facility - date of changes (raw data) – Change in percentage points "
+        "compared to previous rate",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.DFR.LEV",
+        "dataset_name": "Financial market data",
+        "question_subject": "Deposit facility - date of changes (raw data) – Level",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.MRR_RT.LEV",
+        "dataset_name": "Financial market data",
+        "question_subject": "Main refinancing operations - Minimum bid rate/fixed rate (date of changes) "
+        "– Level",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.MLFR.CHG",
+        "dataset_name": "Financial market data",
+        "question_subject": "Marginal lending facility - date of changes (raw data) – Change in "
+        "percentage points compared to previous rate",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.MRR_FR.LEV",
+        "dataset_name": "Financial market data",
+        "question_subject": "Main refinancing operations - fixed rate tenders (fixed rate) (date of "
+        "changes) – Level",
+    },
+    {
+        "id": "ECB/FM/D.U2.EUR.4F.KR.MLFR.LEV",
+        "dataset_name": "Financial market data",
+        "question_subject": "Marginal lending facility - date of changes (raw data) – Level",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_11Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 11-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_28Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 28-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_14Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 14-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_26Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 26-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_19Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 19-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_4Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 4-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_10Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 10-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_24Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 24-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_29Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 29-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_6Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 6-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_15Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 15-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_9Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 9-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_17Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 17-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_29Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 29-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_15Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 15-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_1Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 1-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_11Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 11-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_29Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 29-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_27Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 27-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_9Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 9-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_2Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 2-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_19Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 19-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_13Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 13-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_5Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 5-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_9Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 9-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_17Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 17-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_9Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 9-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_17Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 17-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_4Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 4-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_8Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 8-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 6-month maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_1Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 1-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_18Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 18-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_4Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 4-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_10Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 10-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_15Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 15-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_29Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 29-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_1Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 1-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_29Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 29-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_9Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 9-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_22Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 22-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_23Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 23-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_16Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 16-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_10Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 10-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_19Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 19-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_25Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 25-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_19Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 19-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_21Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 21-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_6Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 6-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_13Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 13-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 6-month maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_22Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 22-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_5Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 5-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_1Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 1-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_15Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 15-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_3Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 3-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_14Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 14-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_18Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 18-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_7Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 7-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_7Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 7-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_6Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 6-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_2Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 2-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_2Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 2-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_17Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 17-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_14Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 14-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_4Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 4-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_22Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 22-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_25Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 25-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_19Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 19-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_27Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 27-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_1Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 1-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_19Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 19-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_5Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 5-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_10Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 10-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_27Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 27-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_13Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 13-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_9Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 9-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_9Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 9-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_11Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 11-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_16Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 16-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_4Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 4-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_3Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 3-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_15Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 15-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_27Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 27-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_2Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 2-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_5Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 5-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_2Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 2-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_7Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 7-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_7Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 7-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_3Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 3-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_23Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 23-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_2Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 2-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_13Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 13-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_6Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 6-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_26Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 26-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_15Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 15-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_3Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 3-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_7Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 7-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_13Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 13-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_11Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 11-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_27Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 27-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_27Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 27-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_8Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 8-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_24Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 24-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_28Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 28-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_23Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 23-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_24Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 24-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_3Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 3-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_8Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 8-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_28Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 28-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_7Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 7-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_24Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 24-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_25Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 25-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_15Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 15-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_1Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 1-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_3Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 3-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_20Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 20-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_10Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 10-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_26Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 26-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_11Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 11-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_11Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 11-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_15Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 15-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_10Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 10-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_27Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 27-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_24Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 24-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_11Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 11-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_2Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 2-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 9-month maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_23Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 23-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_27Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 27-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_20Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 20-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_27Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 27-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_17Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 17-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_19Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 19-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_10Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 10-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_18Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 18-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_9Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 9-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_3Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 3-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_29Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 29-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_1Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 1-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_21Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 21-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_18Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 18-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_3Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 3-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_11Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 11-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_9Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 9-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_13Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 13-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_26Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 26-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_18Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 18-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_16Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 16-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_18Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 18-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_27Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 27-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_27Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 27-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_17Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 17-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_16Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 16-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_2Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 2-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_12Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 12-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_18Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 18-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_26Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 26-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_14Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 14-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_3Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 3-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_19Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 19-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_21Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 21-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_22Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 22-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_1Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 1-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_22Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 22-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_4Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 4-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_8Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 8-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_1Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 1-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_19Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 19-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_24Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 24-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_25Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 25-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_4Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 4-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_29Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 29-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_12Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 12-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_7Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 7-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_20Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 20-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_17Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 17-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_18Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 18-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_26Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 26-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_23Y1M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 23-year 1-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_15Y6M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 15-year 6-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_21Y8M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 21-year 8-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_28Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 28-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_19Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 19-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_4Y2M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 4-year 2-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_10Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 10-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_26Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 26-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_14Y11M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 14-year 11-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_29Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 29-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_7Y3M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 7-year 3-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.IF_29Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve "
+        "instantaneous forward rate, 29-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_28Y4M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 28-year 4-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.PY_22Y5M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Par yield curve "
+        "rate, 22-year 5-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.IF_22Y",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "instantaneous forward rate, 22-year maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_14Y7M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 14-year 7-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.PY_25Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Par yield "
+        "curve rate, 25-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_C.SV_C_YM.SR_13Y9M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – issuers of all ratings – Yield curve "
+        "spot rate, 13-year 9-month residual maturity",
+    },
+    {
+        "id": "ECB/YC/B.U2.EUR.4F.G_N_A.SV_C_YM.SR_16Y10M",
+        "dataset_name": "Financial market data - yield curve",
+        "question_subject": "Euro-area nominal government bonds – AAA-rated issuers – Yield curve spot "
+        "rate, 16-year 10-month residual maturity",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.A050500.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Marginal lending facility (Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.EXLIQ.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Excess liquidity (Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.NLIQ.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Net liquidity effect from Autonomous Factors and MonPol portfolios "
+        "(Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.L020100.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Current accounts (covering the minimum reserves system) (Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.MRR.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Minimum reserve requirements (Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.L020200.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Deposit facility (Eurosystem)",
+    },
+    {
+        "id": "ECB/ILM/D.U2.C.TOMO.U2.EUR",
+        "dataset_name": "Internal Liquidity Management",
+        "question_subject": "Open market operations excl. MonPol portfolios (Eurosystem)",
+    },
+]

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -508,7 +508,7 @@ def make_polymarket_fetch_df(rows):
 
 def make_dbnomics_api_response(
     period_values,
-    provider_name="MeteoFrance",
+    provider_code="meteofrance",
     dataset_name="Temperature",
     series_name="Abbeville",
 ):
@@ -516,19 +516,19 @@ def make_dbnomics_api_response(
 
     Args:
         period_values (list): List of (period_str, value) tuples; value is a float or "NA".
-        provider_name (str): Provider name returned under provider.name.
+        provider_code (str): Provider code returned on the series document.
         dataset_name (str): Dataset name on the series doc.
         series_name (str): Series name on the series doc.
     """
     periods = [p for p, _ in period_values]
     values = [v for _, v in period_values]
     return {
-        "provider": {"name": provider_name},
         "series": {
             "docs": [
                 {
                     "period": periods,
                     "value": values,
+                    "provider_code": provider_code,
                     "dataset_name": dataset_name,
                     "series_name": series_name,
                 }

--- a/src/tests/test_dbnomics.py
+++ b/src/tests/test_dbnomics.py
@@ -26,7 +26,8 @@ _TEST_QUESTIONS = [
             "station at Abbeville will be higher on {resolution_date} than on {forecast_due_date}?"
         ),
         "freeze_datetime_value_explanation": (
-            "The daily average temperature at the French weather station at Abbeville."
+            "The latest value published as of the question-set freeze date for the daily average "
+            "temperature at the French weather station at Abbeville."
         ),
         "fill_missing_dates": False,
     }

--- a/src/tests/test_dbnomics.py
+++ b/src/tests/test_dbnomics.py
@@ -1,13 +1,15 @@
 """Tests for DbnomicsSource: fetch and update logic."""
 
+from collections import Counter
 from datetime import date
 from unittest.mock import Mock, patch
 
 import pandas as pd
+import pytest
 
 from helpers import constants
 from helpers import dbnomics as dbnomics_helper
-from sources.dbnomics import DbnomicsSource
+from sources.dbnomics import DBNOMICS_QUESTIONS, DbnomicsSource
 
 from .conftest import (
     make_dbnomics_api_response,
@@ -15,9 +17,8 @@ from .conftest import (
     make_question_df,
 )
 
-# A small stand-in for the 52-station _CONSTANTS so update tests don't need every series present
-# in dff (legacy/update indexes each series' first row, so absent series would raise).
-_TEST_CONSTANTS = [
+# A small stand-in for DBNOMICS_QUESTIONS so update tests don't need every series present.
+_TEST_QUESTIONS = [
     {
         "id": "meteofrance/TEMPERATURE/celsius.07005.D",
         "question_text": (
@@ -27,6 +28,7 @@ _TEST_CONSTANTS = [
         "freeze_datetime_value_explanation": (
             "The daily average temperature at the French weather station at Abbeville."
         ),
+        "fill_missing_dates": False,
     }
 ]
 _RAW_ID = "meteofrance/TEMPERATURE/celsius.07005.D"
@@ -51,6 +53,45 @@ class TestHelperShim:
         assert (
             isinstance(dbnomics_helper.RESOLUTION_CRITERIA, str)
             and dbnomics_helper.RESOLUTION_CRITERIA
+        )
+
+
+# ---------------------------------------------------------------------------
+# Curated series configuration
+# ---------------------------------------------------------------------------
+
+
+class TestSeriesConfiguration:
+    """The production configuration includes every curated ECB series and MétéoFrance."""
+
+    def test_all_curated_series_are_present_once(self):
+        ecb_questions = [row for row in DBNOMICS_QUESTIONS if row["id"].startswith("ECB/")]
+
+        assert len(ecb_questions) == 458
+        assert len({row["id"] for row in ecb_questions}) == 458
+        assert Counter(row["id"].split("/")[1] for row in ecb_questions) == {
+            "CISS": 32,
+            "EST": 13,
+            "EXR": 200,
+            "FM": 6,
+            "ILM": 7,
+            "YC": 200,
+        }
+        assert all(row["fill_missing_dates"] for row in ecb_questions)
+        assert len(DBNOMICS_QUESTIONS) == 458 + 53
+
+    def test_ecb_question_states_the_latest_available_value_policy(self):
+        row = next(row for row in DBNOMICS_QUESTIONS if row["id"] == "ECB/EXR/D.USD.EUR.SP00.A")
+
+        assert row["question_text"] == (
+            "What is the probability that the value of the latest observation dated on or before "
+            "{resolution_date} for the European Central Bank time series “US dollar per euro "
+            "spot exchange rate” will exceed the value of its latest observation dated on or "
+            "before {forecast_due_date}?"
+        )
+        assert row["freeze_datetime_value_explanation"] == (
+            "The latest value published as of the question-set freeze date for “US dollar "
+            "per euro spot exchange rate” in the European Central Bank’s “Exchange Rates” dataset."
         )
 
 
@@ -80,6 +121,29 @@ class TestCallEndpoint:
         assert df["id"].unique().tolist() == [_SAFE_ID]
         assert set(df["period"]) == {date(2025, 1, 1), date(2026, 1, 14)}
 
+    def test_omits_repeated_metadata_and_keeps_provider_names(self, dbnomics_source):
+        provider_names = {
+            "ECB": "European Central Bank",
+            "meteofrance": "Météo-France",
+        }
+        for provider_code, provider_name in provider_names.items():
+            resp = Mock()
+            resp.ok = True
+            resp.json.return_value = make_dbnomics_api_response(
+                [("2026-01-14", 7.0)], provider_code=provider_code
+            )
+
+            with patch("sources.dbnomics.requests.get", return_value=resp) as mocked:
+                df = dbnomics_source._call_endpoint(id=_RAW_ID, today=date(2026, 1, 15))
+
+            assert mocked.call_args.kwargs["params"] == {
+                "observations": 1,
+                "metadata": 0,
+            }
+            assert "Authorization" not in mocked.call_args.kwargs.get("headers", {})
+            assert mocked.call_args.kwargs["timeout"] == (10, 60)
+            assert df["provider_name"].unique().tolist() == [provider_name]
+
     def test_returns_none_when_window_empty(self, dbnomics_source):
         today = date(2026, 1, 15)
         resp = Mock()
@@ -99,7 +163,7 @@ class TestCallEndpoint:
 class TestFetch:
     """fetch() threads a single 'today' and concatenates per-series frames."""
 
-    @patch("sources.dbnomics._CONSTANTS", _TEST_CONSTANTS)
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
     def test_concatenates_and_casts_period_to_str(self, dbnomics_source, freeze_today):
         freeze_today(date(2026, 1, 15))
         fake = pd.DataFrame(
@@ -120,6 +184,40 @@ class TestFetch:
         assert dff["period"].tolist() == ["2026-01-13", "2026-01-14"]
         assert dff["id"].tolist() == [_SAFE_ID, _SAFE_ID]
 
+    @patch(
+        "sources.dbnomics.DBNOMICS_QUESTIONS",
+        [{"id": "series/one"}, {"id": "series/empty"}, {"id": "series/two"}],
+    )
+    def test_returns_rows_from_nonempty_series_in_source_order(self, dbnomics_source, freeze_today):
+        """Skip empty endpoint results without changing source order."""
+        freeze_today(date(2026, 1, 15))
+        first = make_dbnomics_fetch_df(
+            [{"id": "series_one", "period": date(2026, 1, 13), "value": 5.0}]
+        )
+        second = make_dbnomics_fetch_df(
+            [{"id": "series_two", "period": date(2026, 1, 14), "value": 6.0}]
+        )
+
+        with patch.object(DbnomicsSource, "_call_endpoint", side_effect=[first, None, second]):
+            dff = dbnomics_source.fetch()
+
+        assert dff["id"].tolist() == ["series_one", "series_two"]
+        assert dff["period"].tolist() == ["2026-01-13", "2026-01-14"]
+
+    @patch(
+        "sources.dbnomics.DBNOMICS_QUESTIONS",
+        [{"id": "series/one"}, {"id": "series/two"}],
+    )
+    def test_raises_clear_error_when_all_series_are_empty(self, dbnomics_source, freeze_today):
+        """Fail the fetch rather than producing an empty output file."""
+        freeze_today(date(2026, 1, 15))
+
+        with patch.object(DbnomicsSource, "_call_endpoint", return_value=None):
+            with pytest.raises(
+                RuntimeError, match="No DBnomics series returned usable observations"
+            ):
+                dbnomics_source.fetch()
+
 
 # ---------------------------------------------------------------------------
 # update
@@ -129,7 +227,67 @@ class TestFetch:
 class TestUpdate:
     """update() builds resolution files for every series and upserts questions."""
 
-    @patch("sources.dbnomics._CONSTANTS", _TEST_CONSTANTS)
+    @pytest.mark.parametrize("age,excluded", [(7, False), (10, False), (11, True)])
+    @pytest.mark.parametrize("existing", [False, True])
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
+    def test_freshness_controls_new_and_existing_question_eligibility(
+        self, dbnomics_source, freeze_today, age, excluded, existing
+    ):
+        """A real observation within ten days permits curation, including after recovery."""
+        freeze_today(date(2026, 1, 15))
+        dfq = make_question_df([{"id": _SAFE_ID, "resolved": True}]) if existing else _empty_dfq()
+        dff = make_dbnomics_fetch_df(
+            [{"id": _SAFE_ID, "period": f"2026-01-{15 - age:02d}", "value": 6.0}]
+        )
+
+        result = dbnomics_source.update(dfq, dff)
+
+        eligible = result.dfq.loc[~result.dfq["resolved"], "id"].tolist()
+        assert (_SAFE_ID not in eligible) == excluded
+        assert bool(dbnomics_source.freshness_warnings) == excluded
+        assert _SAFE_ID in result.resolution_files
+
+    @patch(
+        "sources.dbnomics.DBNOMICS_QUESTIONS",
+        [{**_TEST_QUESTIONS[0], "fill_missing_dates": True}],
+    )
+    def test_recent_missing_rows_and_forward_fill_do_not_hide_staleness(
+        self, dbnomics_source, freeze_today
+    ):
+        """Use the last real observation, regardless of row order or filled resolution dates."""
+        freeze_today(date(2026, 1, 15))
+        dff = make_dbnomics_fetch_df(
+            [
+                {"id": _SAFE_ID, "period": "2026-01-14", "value": "NA"},
+                {"id": _SAFE_ID, "period": "2026-01-01", "value": 6.0},
+            ]
+        )
+        dfq = make_question_df([{"id": _SAFE_ID}])
+
+        result = dbnomics_source.update(dfq, dff)
+
+        assert result.dfq.iloc[0]["resolved"]
+        assert "2026-01-01" in dbnomics_source.freshness_warnings[0]
+        assert result.resolution_files[_SAFE_ID]["date"].iloc[-1] == "2026-01-14"
+
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
+    def test_recovery_clears_warnings_and_reenables_existing_question(
+        self, dbnomics_source, freeze_today
+    ):
+        """A previously stale series becomes eligible again when observations resume."""
+        freeze_today(date(2026, 1, 15))
+        dfq = make_question_df([{"id": _SAFE_ID}])
+        stale = make_dbnomics_fetch_df([{"id": _SAFE_ID, "period": "2026-01-01", "value": 6.0}])
+        result = dbnomics_source.update(dfq, stale)
+        assert result.dfq.iloc[0]["resolved"]
+        fresh = make_dbnomics_fetch_df([{"id": _SAFE_ID, "period": "2026-01-14", "value": 6.0}])
+
+        result = dbnomics_source.update(result.dfq, fresh)
+
+        assert not result.dfq.iloc[0]["resolved"]
+        assert dbnomics_source.freshness_warnings == []
+
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
     def test_new_question_inserted_with_resolution_file(self, dbnomics_source, freeze_today):
         freeze_today(date(2026, 1, 15))
         dff = make_dbnomics_fetch_df(
@@ -144,12 +302,13 @@ class TestUpdate:
         row = result.dfq[result.dfq["id"] == _SAFE_ID].iloc[0]
         assert not row["resolved"]
         assert row["url"] == f"https://db.nomics.world/{_RAW_ID}"
+        assert row["freeze_datetime_value"] == "6.0"
 
         assert _SAFE_ID in result.resolution_files
         rf = result.resolution_files[_SAFE_ID]
         assert list(rf.columns) == ["id", "date", "value"]
 
-    @patch("sources.dbnomics._CONSTANTS", _TEST_CONSTANTS)
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
     def test_existing_question_updated_in_place(self, dbnomics_source, freeze_today):
         freeze_today(date(2026, 1, 15))
         dff = make_dbnomics_fetch_df(
@@ -169,7 +328,36 @@ class TestUpdate:
         row = result.dfq[result.dfq["id"] == _SAFE_ID].iloc[0]
         assert row["freeze_datetime_value"] == "6.0"
 
-    @patch("sources.dbnomics._CONSTANTS", _TEST_CONSTANTS)
+    @patch(
+        "sources.dbnomics.DBNOMICS_QUESTIONS",
+        [
+            {
+                **_TEST_QUESTIONS[0],
+                "id": "meteofrance/TEMPERATURE/celsius.07015.D",
+            },
+            _TEST_QUESTIONS[0],
+        ],
+    )
+    def test_missing_series_is_preserved_while_available_series_is_processed(
+        self, dbnomics_source, freeze_today
+    ):
+        """Exclude a missing series from curation while preserving its history."""
+        freeze_today(date(2026, 1, 15))
+        missing_id = "meteofrance_TEMPERATURE_celsius.07015.D"
+        dfq = make_question_df([{"id": missing_id, "freeze_datetime_value": "stale"}])
+        dff = make_dbnomics_fetch_df([{"id": _SAFE_ID, "period": "2026-01-14", "value": 6.0}])
+
+        result = dbnomics_source.update(dfq, dff)
+
+        missing_row = result.dfq[result.dfq["id"] == missing_id].iloc[0]
+        assert missing_row["freeze_datetime_value"] == "stale"
+        assert missing_row["resolved"]
+        assert any("no fetched observations" in w for w in dbnomics_source.freshness_warnings)
+        assert missing_id not in result.resolution_files
+        assert _SAFE_ID in result.dfq["id"].tolist()
+        assert _SAFE_ID in result.resolution_files
+
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
     def test_all_na_window_skipped_from_questions_but_resolution_built(
         self, dbnomics_source, freeze_today
     ):
@@ -183,7 +371,7 @@ class TestUpdate:
         assert _SAFE_ID not in result.dfq["id"].tolist()
         assert _SAFE_ID in result.resolution_files  # resolution file still written
 
-    @patch("sources.dbnomics._CONSTANTS", _TEST_CONSTANTS)
+    @patch("sources.dbnomics.DBNOMICS_QUESTIONS", _TEST_QUESTIONS)
     def test_resolution_file_na_to_not_available_and_values_are_strings(
         self, dbnomics_source, freeze_today
     ):
@@ -201,3 +389,75 @@ class TestUpdate:
         assert "N/A" in values  # "NA" rewritten
         assert "NA" not in values
         assert "6.0" in values  # numeric value preserved as a string (legacy parity)
+
+    @patch(
+        "sources.dbnomics.DBNOMICS_QUESTIONS",
+        [{**_TEST_QUESTIONS[0], "fill_missing_dates": True}],
+    )
+    def test_values_are_carried_forward_over_omitted_and_unavailable_dates(
+        self, dbnomics_source, freeze_today
+    ):
+        freeze_today(date(2026, 1, 13))
+        dff = make_dbnomics_fetch_df(
+            [
+                {"id": _SAFE_ID, "period": "2026-01-09", "value": "5.0"},
+                {"id": _SAFE_ID, "period": "2026-01-11", "value": "NA"},
+                {"id": _SAFE_ID, "period": "2026-01-12", "value": "6.0"},
+            ]
+        )
+
+        result = dbnomics_source.update(_empty_dfq(), dff)
+        resolution = result.resolution_files[_SAFE_ID].set_index("date")
+
+        assert resolution.loc["2026-01-10", "value"] == "5.0"
+        assert resolution.loc["2026-01-11", "value"] == "5.0"
+        assert resolution.loc["2026-01-12", "value"] == "6.0"
+
+
+class TestFreshnessAlert:
+    """The update job reports stale series after persisting the exclusion."""
+
+    def test_alert_is_aggregated_and_bounded(self):
+        from orchestration.func_dbnomics_update import main
+
+        slack = Mock()
+        warnings = [f"series-{i}: latest non-missing observation 2026-01-01" for i in range(25)]
+        with patch.object(main, "import_module", return_value=slack):
+            main._alert_stale_series(warnings)
+        slack.send_message.assert_called_once()
+        message = slack.send_message.call_args.kwargs["message"]
+        assert "25 series excluded" in message
+        assert "10 days" in message
+        assert "series-0:" in message and "series-19:" in message
+        assert "5 more" in message
+
+    def test_no_alert_for_fresh_series(self):
+        from orchestration.func_dbnomics_update import main
+
+        with patch.object(main, "import_module") as load:
+            main._alert_stale_series([])
+        load.assert_not_called()
+
+    def test_notification_failure_does_not_abort_update(self):
+        from orchestration.func_dbnomics_update import main
+
+        with patch.object(main, "import_module", side_effect=RuntimeError("Slack unavailable")):
+            main._alert_stale_series(["series: no fetched observations"])
+
+    def test_driver_uploads_before_alerting(self):
+        from orchestration.func_dbnomics_update import main
+
+        events = []
+        source = Mock()
+        source.freshness_warnings = ["series: no fetched observations"]
+        source.update.return_value = Mock(dfq=_empty_dfq(), resolution_files={})
+        with (
+            patch.object(main, "DbnomicsSource", return_value=source),
+            patch.object(main.data_utils, "get_data_from_cloud_storage", return_value=(None, None)),
+            patch.object(
+                main.data_utils, "upload_questions", side_effect=lambda *a: events.append("upload")
+            ),
+            patch.object(main, "_alert_stale_series", side_effect=lambda w: events.append(w)),
+        ):
+            main.driver(None)
+        assert events == ["upload", source.freshness_warnings]

--- a/src/tests/test_runtime_requirements.py
+++ b/src/tests/test_runtime_requirements.py
@@ -90,6 +90,17 @@ def test_metadata_deploy_requirements_keep_direct_gcp_deps():
         assert "google-cloud-secret-manager" in requirements
 
 
+def test_dbnomics_update_declares_slack_runtime_dependency():
+    """A fresh update-job deployment must support stale-series Slack notifications."""
+    requirements_path = ROOT / "src/orchestration/func_dbnomics_update/requirements.txt"
+    requirement_names = {
+        re.split(r"[<>=!~\[;]", line, maxsplit=1)[0].strip().lower().replace("_", "-")
+        for line in requirements_path.read_text().splitlines()
+    }
+
+    assert "slack-sdk" in requirement_names
+
+
 def test_root_makefile_routes_llm_baseline_targets_to_refactored_jobs():
     makefile = (ROOT / "Makefile").read_text()
 


### PR DESCRIPTION
## Summary

Adds 458 curated ECB series to DBnomics, expanding it from 53 to 511 series.

Increases the DBnomics job memory and timeout limits to support the larger workload.

Excludes series with missing data or no non-missing observation within 10 days from new question sets and sends a Slack notification. Series become eligible again when fresh observations resume.