### PR TITLE
fix: include only `variables.mk` from the root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 .DEFAULT_GOAL := lint
 
-include *.mk
+-include variables.mk
 export CLOUD_PROJECT
 export QUESTION_BANK_BUCKET
 export QUESTION_BANK_BUCKET_SERVICE_ACCOUNT


### PR DESCRIPTION
`include *.mk` also pulled in `deploy_config.mk` and `orchestration_upload.mk`, which gave the root Makefile `Dockerfile` and `.gcloudignore` rules it never meant to have. Include the local config file by name instead.