### PR TITLE
Fix/287 yfinance delisted renamed

### DIFF
--- a/src/sources/_metadata.py
+++ b/src/sources/_metadata.py
@@ -437,8 +437,11 @@ SOURCE_METADATA = {
             NullifiedQuestion(id="HES", nullification_start_date=date(2025, 7, 18)),
             NullifiedQuestion(id="PARA", nullification_start_date=date(2025, 8, 7)),
             NullifiedQuestion(id="WBA", nullification_start_date=date(2025, 8, 28)),
+            NullifiedQuestion(id="IPG", nullification_start_date=date(2025, 11, 27)),
             NullifiedQuestion(id="K", nullification_start_date=date(2025, 12, 11)),
             NullifiedQuestion(id="DAY", nullification_start_date=date(2026, 2, 4)),
+            NullifiedQuestion(id="HOLX", nullification_start_date=date(2026, 4, 7)),
+            NullifiedQuestion(id="CTRA", nullification_start_date=date(2026, 5, 7)),
         ],
         # Tickers that were renamed on yfinance while still in the question pool. yfinance serves
         # all price history under the replacement ticker; the original ticker returns no data. The
@@ -448,6 +451,7 @@ SOURCE_METADATA = {
             {"original_ticker": "FI", "replacement_ticker": "FISV"},
             {"original_ticker": "MMC", "replacement_ticker": "MRSH"},
             {"original_ticker": "BK", "replacement_ticker": "BNY"},
+            {"original_ticker": "SATS", "replacement_ticker": "ECHO"},
         ],
     },
 }

--- a/src/sources/yfinance.py
+++ b/src/sources/yfinance.py
@@ -146,20 +146,18 @@ class YfinanceSource(DatasetSource):
                     }
                 )
                 logger.info(company_name)
-            elif (
-                company_name is None
-                and ticker_symbol in set_current
-                and ticker_symbol not in set_top_500
-            ):
-                # In the question pool, no longer fetchable, and out of the S&P 500, but not in any
-                # curated list: either newly delisted or newly renamed. Carry the existing row
-                # forward as resolved and record it so the driver can flag it for triage.
+            elif ticker_symbol in set_current and ticker_symbol not in set_top_500:
+                # In the question pool, no usable price data (no name or no price history), and
+                # out of the S&P 500, but not in any curated list: either newly delisted or newly
+                # renamed. Carry the existing row forward as resolved and record it so the driver
+                # can flag it for triage.
                 rows.append(self._carry_forward_resolved(ticker_symbol, dfq, current_time))
                 self.uncurated_delisted_tickers.append(ticker_symbol)
                 logger.warning(
-                    f"{ticker_symbol} failed to fetch and is no longer in the S&P 500 (likely "
-                    "delisted or renamed). If delisted, add it to nullified_questions; if renamed, "
-                    "add it to ticker_renames (mapping it to its replacement symbol)."
+                    f"{ticker_symbol} returned no usable price data (no name or no price "
+                    "history) and is no longer in the S&P 500 (likely delisted or renamed). "
+                    "If delisted, add it to nullified_questions; if renamed, add it to "
+                    "ticker_renames (mapping it to its replacement symbol)."
                 )
 
         return pd.DataFrame(rows)
@@ -306,11 +304,13 @@ class YfinanceSource(DatasetSource):
             ticker_symbol (str): Stock ticker symbol.
 
         Returns:
-            Tuple of (company_name, hist_df) or (None, None) on failure.
+            Tuple of (company_name, hist_df), where company_name is None when yfinance has
+            no name for the ticker, or (None, None) on failure.
         """
         try:
             ticker = yf.Ticker(ticker_symbol)
-            company_name = ticker.info["longName"]
+            info = ticker.info
+            company_name = info.get("longName") or info.get("shortName")
             hist = ticker.history(period="5d", auto_adjust=False).reset_index()
             yesterday = self.get_date_today() - timedelta(days=1)
             hist["Date"] = pd.to_datetime(hist["Date"])

--- a/src/tests/test_yfinance.py
+++ b/src/tests/test_yfinance.py
@@ -36,6 +36,7 @@ class TestTickerRenamesDefinition:
         assert renames["FI"] == "FISV"
         assert renames["MMC"] == "MRSH"
         assert renames["BK"] == "BNY"
+        assert renames["SATS"] == "ECHO"
 
 
 class TestDelistedStocksDefinition:
@@ -48,7 +49,21 @@ class TestDelistedStocksDefinition:
 
     def test_known_delisted_tickers_present(self):
         ids = {nq.id for nq in DELISTED_STOCKS}
-        expected = {"MRO", "CTLT", "DFS", "JNPR", "ANSS", "HES", "PARA", "WBA", "K", "DAY"}
+        expected = {
+            "MRO",
+            "CTLT",
+            "DFS",
+            "JNPR",
+            "ANSS",
+            "HES",
+            "PARA",
+            "WBA",
+            "IPG",
+            "K",
+            "DAY",
+            "HOLX",
+            "CTRA",
+        }
         assert ids == expected
 
     def test_nullification_dates_are_day_after_last_trade(self):
@@ -61,8 +76,11 @@ class TestDelistedStocksDefinition:
         assert date_map["HES"] == date(2025, 7, 18)
         assert date_map["PARA"] == date(2025, 8, 7)
         assert date_map["WBA"] == date(2025, 8, 28)
+        assert date_map["IPG"] == date(2025, 11, 27)
         assert date_map["K"] == date(2025, 12, 11)
         assert date_map["DAY"] == date(2026, 2, 4)
+        assert date_map["HOLX"] == date(2026, 4, 7)
+        assert date_map["CTRA"] == date(2026, 5, 7)
 
 
 class TestYfinanceSourceNullification:
@@ -73,7 +91,7 @@ class TestYfinanceSourceNullification:
         return YfinanceSource()
 
     def test_source_has_nullified_questions(self, source):
-        assert len(source.nullified_questions) == 10
+        assert len(source.nullified_questions) == 13
 
     def test_pre_delisting_question_not_nullified(self, source):
         """JNPR in the 2025-03-30 question set should NOT be nullified (delisted 2025-07-02)."""
@@ -267,9 +285,26 @@ class TestSourceFetchOneStock:
         assert out["Close"].iloc[-1] == 254.23  # capped at yesterday, last row
 
     @patch("sources.yfinance.yf.Ticker")
+    def test_falls_back_to_short_name(self, mock_ticker_cls, yfinance_source, freeze_today):
+        """Yahoo omits longName for some live tickers, which must not look like a delisting."""
+        freeze_today(date(2026, 3, 18))
+        mock_ticker = MagicMock()
+        mock_ticker.info = {"shortName": "Match Group, Inc."}
+        hist = pd.DataFrame(
+            {"Date": pd.to_datetime(["2026-03-16", "2026-03-17"]), "Close": [40.5, 41.22]}
+        ).set_index("Date")
+        mock_ticker.history.return_value = hist
+        mock_ticker_cls.return_value = mock_ticker
+
+        name, out = yfinance_source._fetch_one_stock("MTCH")
+
+        assert name == "Match Group, Inc."
+        assert out["Close"].iloc[-1] == 41.22
+
+    @patch("sources.yfinance.yf.Ticker")
     def test_returns_none_on_error(self, mock_ticker_cls, yfinance_source):
         """Returns (None, None) when the ticker lookup fails (legacy-faithful swallow)."""
-        mock_ticker_cls.return_value.info.__getitem__.side_effect = KeyError("longName")
+        mock_ticker_cls.side_effect = Exception("yfinance unavailable")
         assert yfinance_source._fetch_one_stock("INVALID") == (None, None)
 
 


### PR DESCRIPTION
fix: update delisted and renamed yfinance tickers

IPG was delisted 2025-11-28 when the Omnicom acquisition closed: https://www.omc.com/newsroom/omnicom-completes-acquisition-of-interpublic-forming-the-worlds-leading-marketing-and-sales-company-built-for-intelligent-growth-in-the-next-era/ ; https://stockanalysis.com/stocks/ipg/

HOLX was delisted 2026-04-07, taken private by Blackstone and TPG: https://www.hologic.com/about/press-release/blackstone-and-tpg-complete-acquisition-hologic ; https://stockanalysis.com/stocks/holx/

CTRA was delisted 2026-05-07, merged into Devon Energy: https://investors.devonenergy.com/investors/press-releases/press-release-details/2026/Devon-Energy-and-Coterra-Energy-Complete-Merger/ ; https://stockanalysis.com/stocks/ctra/

SATS was renamed to ECHO on 2026-06-24, still trading on Nasdaq: https://www.lightreading.com/satellite/echostar-to-change-stock-ticker-to-echo- 

MTCH is neither delisted nor renamed, still trading on Nasdaq: https://stockanalysis.com/stocks/mtch/ It only dropped out of the S&P 500 in the March 2026 rebalance, and the fetch failure had a different cause. For some reason Yahoo did not return "longName" value for MTCH which caused a delisting. Added a fall back to shortName to restore the normal fetch. 

Nullification dates are last trading day + 1, so 2025-11-27 for IPG, 2026-04-07 for HOLX and 2026-05-07 for CTRA. Verified those against the last real price change in each resolution file.

Also added a test to see if the MTCH handling worked, let me know if you think this isn't needed. 

Closes #287